### PR TITLE
Ignore `repro-env.lock` entries with `installed = true`

### DIFF
--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,21 +1,13 @@
 [container]
-image = "docker.io/library/archlinux@sha256:b29dab0d5f362cfe2ed4662c46f27855681d56fb548fd2f6d927fd573131178a"
+image = "docker.io/library/archlinux@sha256:a29547d0d844b7393a3d76dbaa3fdee4b1bdb8423fb0f114877737fda1cf9c41"
 
 [[package]]
 name = "archlinux-keyring"
-version = "20230821-2"
+version = "20230918-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20230821-2-any.pkg.tar.zst"
-sha256 = "1adcb1f1599b24ff357573996e4064ba9155f90e7998c3289520f6d97ca20189"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZOxGUgAKCRBtQr3RFuAGj/MKAP0e96Vs3RkIBXDQW+WaMlllDmVe7Sze6Sc0IOQqhLyk3QD/fS9Ldoan80/NQJzDlCkd+KjIx6U8VBiFwv1++WHXoAM="
-
-[[package]]
-name = "audit"
-version = "3.1.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/audit/audit-3.1.2-1-x86_64.pkg.tar.zst"
-sha256 = "2f82b4e4e4e38132397a4a5bfb8a1b2d45a7a522473e8e841fdbf965d634efd8"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZNDHzAAKCRATmwnaW/DTOGQVAQCKYLj2qV0KLiw7R68hgFj+2i5Apj5N8eYRogbEfPs0+wEAxWfjineCRRM7AR3TVACspd4I9gvhw47mD+bmF8y4zgw="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20230918-1-any.pkg.tar.zst"
+sha256 = "d6486bea994ed6b98808dde01049fbe967c16e2672829c7befeff0fe8ea75fa7"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZQfidgAKCRBtQr3RFuAGj4IyAQDqra9j77RRCLep28YhtqRiz8yxsXGIo279oVtlHRGyIAEA/0uzy4pmsksGa04o5HZhYIz1gxX130az8f2LSt3+XwY="
 
 [[package]]
 name = "binutils"
@@ -26,36 +18,12 @@ sha256 = "b921c57f7847a3daa4025c961cfa573f1f5244e9f84e673edba4fc4fbfd09a70"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZM0fcl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCjWSAP90OJtRaSrRM6tQAaNseK66rjp/UNeexmEGKk3hVSAHOQEApYk913azGyXlSJCDu6NpPJXII1BcBnuR/62p4KpSuwU="
 
 [[package]]
-name = "ca-certificates-mozilla"
-version = "3.92-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.92-1-x86_64.pkg.tar.zst"
-sha256 = "0deefc5884e37867e608df6eb440846b21e9d4bf12f1ae20088a149703e5acd2"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZML0wxUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8c33wEAh7y67JJL4O5eHLbBsDjb2U1f44Ek7WEYFBEWazNmFugBANqH3H/8tF9p8jVXstp5x00MREtFw+T+jhraOIjqh4sK"
-
-[[package]]
 name = "curl"
-version = "8.2.1-1"
+version = "8.3.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/curl/curl-8.2.1-1-x86_64.pkg.tar.zst"
-sha256 = "5ce8b218ecbc75a097b683e81fe901b7e144064ceeeca073fc8a0ea3b0b2ce4d"
-signature = "iQIzBAABCAAdFiEEtLdZYl1GM0MLdIdwWeQ+EGskc2gFAmTA4X0ACgkQWeQ+EGskc2hvTw//fLUtrOsXvDMDclh6vwccHz9uSK2EpHNuFTpyd3Jx4bK66ZwePTIgMVgNJxmnbso77G+eyhb4QpCTuu1fJdSrXgaVqAYR21uWNuHLVKSyT9+L7LvSbnXdhMzGLLN3bY6UqfGirSKMQOOLXsxUFvCHovqHkspjbXLDejJA/eGdIBx2V2BoDa5xLIXz2QDAPuevwMBrHv+C682uiEr/5ihmsn363K9TX+9B7Pbreu4FvY/tnMMkzeG0+NiuylLbYz3egkZwhFO0mX9ZgxzkUOx8Bx/qqK+Slo0bIYNI274Iz25dexq06rbEFlOp7DM1b4zMYCDYNWI+RTPX0RbQXOJfoX+AhwLdZvf9pf3cT3BLpIaCVrWNI5nPd/5+aQY0tcY1y7A4VA+66/melwtDB17PAKengdWqjVs3BOtBRs1aT4Zew4RmNS1n5NGarxCJM/yrzPC0Xz6piE4atmf1Fzaz8pRViVVejUk1uIFqKIUmtZtO1qSkbeTLRE/e4orVBfeasYlaUsCBtnsHMeqYy9BK2a+IvLk7o17trlIP1niFuIqbXexu+rusPt8Wn4IQlZvT+dyWMcRP4OFBHAECieE5GaoWPcTScFDOifpdPk7FShXX8C441xcjb0pomGSW/JFBKD1CSlMuUVhqF5p/NkE4smP+yKrdHOYtqo1LdejItaw="
-
-[[package]]
-name = "device-mapper"
-version = "2.03.22-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/d/device-mapper/device-mapper-2.03.22-2-x86_64.pkg.tar.zst"
-sha256 = "1a717b916b12852a2a67f16b201a392a4adb3f3e06fb77c054a76608c7e0198d"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNs11wAKCRBtQr3RFuAGj6JtAQDHb4vbPhK28J2wwI3HcgZXUt5cmmGXS8uUCksiyR/ZUwEA4qO+sVVl8X4aATWtMUZUVNWQcT72v5XFvmc2TbAUPAs="
-
-[[package]]
-name = "file"
-version = "5.45-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/f/file/file-5.45-1-x86_64.pkg.tar.zst"
-sha256 = "3ad37e246e893cdf59ae3af862d083c52087c47d3e6210996075ce77d41c5a1a"
-signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZMLglQAKCRDluymEcK1OQb62AP9hE3dXkRFkEUgk+qhvr2G1YPDwGJq74nOouLS4U/SO+AD+O3z89uX6mLEdf56VSygb769wpeUwt54vTvNJy11qGgI="
+url = "https://archive.archlinux.org/packages/c/curl/curl-8.3.0-1-x86_64.pkg.tar.zst"
+sha256 = "ff7951b5950a3a0319e86988041db4438b31a6ee4c7a36c64bd6c0c4607e40c9"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZQFdGwAKCRBtQr3RFuAGjz/hAP92UdopucLXJgxH4aAgoyH4YueeZ4tD8XO658SZT4SDlwD/fDGvD4eudh7ww97zE0ciHo2YwZHOVA9TgXt5fOkUYQM="
 
 [[package]]
 name = "gc"
@@ -74,44 +42,12 @@ sha256 = "c28a0e0c90a9f2c946b0e3c969742eb872229bb352c44e943e6aa101f60c7d04"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMoUtF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCouZAP0YU8C2MiqVEgJF2sJUVBTjphdU5qfPLTH4wTfrqYaJ6wEAiFydzaI9ORiQYQ9Y4SH6aHBD6S4BN+gnm0FjDCWMxgk="
 
 [[package]]
-name = "gcc-libs"
-version = "13.2.1-3"
+name = "glib2"
+version = "2.78.0-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-13.2.1-3-x86_64.pkg.tar.zst"
-sha256 = "8d4658790a832599b38c6403ce669d19f64fbdaddbe59c30213b192b898459e7"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMoUtF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaChntAQDCHJgEmLOk2LdTlOYm5KFVTxoN2eOOy2R2ouWLc7TTkwEA5zyEqic/i3v4buMRdb9TrmEO1B7ZQPtKTYNwb1R/RAM="
-
-[[package]]
-name = "glibc"
-version = "2.38-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glibc/glibc-2.38-3-x86_64.pkg.tar.zst"
-sha256 = "e85b4e50da81bb80515c95093d5c3dc38c5428d7d5a3772eb0d9a7a6210f6748"
-signature = "iNQEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZN5CFl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmozAQD9JOoMGJnvTVyTslMXKFtS6Ria11NI0X3k+X3mmSjEogD48N2v4SrqQc3O0Q2pdel+VZudQuimI7ET/m15yicCBA=="
-
-[[package]]
-name = "gmp"
-version = "6.3.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gmp/gmp-6.3.0-1-x86_64.pkg.tar.zst"
-sha256 = "46ca028cb30a263fc5163348ad057a10b363dc5c6a59ff50b2fa5dd405acf755"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmTGonsACgkQek52CV2KUuRyFQf+NB0IJ4L3sXM03JCMQp8jIjEPqmeLC+VYm5jRJKqFbs3++vpMdXEK5vX9mMdqSA1UtmJRllEDX0uabUkr8msO3ZdzvCG8GmgzeZph0cafDlUVTR6Fk2wRklCuC06uPt6ko83pTfkvLd6MTT0Hp6KSes/8tCigKsIv0R+Uqqj8NpJTiGUeKtMoSZxlQoB/1yiEdQmXRT6uYgiRj5kEJ9SE29gBzH1Mve5uuR3Tl1DXbuMDeXs2THjk9xmz964bSNxFqVpVy3/85zVsGkNcDRZIJtXyrzeP9PI/FQIF8taaE+4ATaZjOT6J7rP7NCnr9poAB2ui1W7Pr2u1FH6ZrTtHQQ=="
-
-[[package]]
-name = "gnutls"
-version = "3.8.1-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gnutls/gnutls-3.8.1-1-x86_64.pkg.tar.zst"
-sha256 = "f951a1d18e25d3008ee5b1ac72742a57125b72fde64318918bdcde0bf7dd9743"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmTYbEYACgkQlGV6sg8qCStIjAf/eWEZhvAtE1FzCStUaZ+UCjBwTm3NUb2A/xtpilvDzL6VWCuma+//6Bo+nGjUbCd/0jZ6LS0miTVjrweBIYIOeUqAJRl1B7g8KGu301D69stj4mGpa3oVcWZlTkqHPOeOl9gyLrWFg1Ms1VnPhjNnYHxk/9N/bz2K8Xr843woelzOBE99huUsZ+iVcVHUHobHCwhgf6LrDy2SMXvjNHGt1kRFq0J7QRvCD4JwjJTdw5fXay3mL9hGbGUqYPiVcUPWIVI+OCaLdHRGPto9BEbCjF3MGBNFsN6ccCgJ0lVAX+L6w02IL6y4ehjLki75ClM0arog3Gr1p6bOCkfJ7NpRaQ=="
-
-[[package]]
-name = "gpgme"
-version = "1.22.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gpgme/gpgme-1.22.0-1-x86_64.pkg.tar.zst"
-sha256 = "61bf13c95502d5955eb70e52ef65f64d4e3a19c812c2c01e09c74c8ae753b4ae"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZOPkLwAKCRBtQr3RFuAGj4myAQCYuSucvgYfwXsFy44qb4yssDwSu7IX8Lq7JWXxp7WO9QEAnhfFyLc4KxIq/DID0SQGrLv2wmATWRPvpuGm1FreJgU="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.78.0-2-x86_64.pkg.tar.zst"
+sha256 = "893cd820cdf1cc60cfafd621e280a0bc48fcf11aaa92e2f22ebc9eadf71a2157"
+signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZP9+cxUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8dSvAEA9PpRt/wlvCKGjeLB/MWCdx90iw0RTbTHKHmrE+f4AdcBAIV0lGpjnCAsRSQijVaUASPTR9zcMn8sIIsTIV22jdwO"
 
 [[package]]
 name = "guile"
@@ -122,30 +58,6 @@ sha256 = "1c17a7b5c3c9c6ca580c76b36080603587bd2dc39a2c3cb0f07d755da05126ab"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCY9Gy3F8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCt5aAQDMcoBQsIEeLWacejGD+7TLT6F3Nu1Q3KDaNAZojqkwmQEAsvIVi/edva/VSJY9fHvmrcdV7jJrRjqglpWinxuWPQI="
 
 [[package]]
-name = "gzip"
-version = "1.12-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gzip/gzip-1.12-3-x86_64.pkg.tar.zst"
-sha256 = "4204ed3a9c24398106d6c81e5a874e67e3c840b7329b741c8f16abdbcc8086c2"
-signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZNs/vAAKCRDluymEcK1OQRQaAP4w0l9NcTg8JRPrwAn/bD6Vc2RV8SHDl/i8kh3LsudQSwEAmJP9INIasKE8AkxNSWlXxdA/lRAtSHx7h8KQp77Ubg0="
-
-[[package]]
-name = "hwdata"
-version = "0.373-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/h/hwdata/hwdata-0.373-1-any.pkg.tar.zst"
-sha256 = "97aa59b40dd132a8775d71b46a3d8f5abb2100ce19f8fd2c2baff6ac7c74a899"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmTcaBUACgkQdx32Yn7faB8mnQgAkRXu4n18IBCftQPM442cDtxVWuYedXPlwpSIE/IRVCGNZrZWkbUswpZBNelHaIhkFnrRIvkcHsV2yzfNlojaIhcMSE7Rjoqt9ulhSN8acwtPimbZ1X8BkSESFuautaCnzzH+d8YFiatc3xr50lfwDx97w5sTPew2gvIdugBo4WbTPCpePuMRzYRNoNSVN027CzWq93qdOr/8okJyiL7CyBoe1dHym4kuWgeCSYmZYH49lMgdBFN+CDS0QrtWlk0soXnj1OfKGVCBQa8vhDrn8HwinKU3LxDd3r0s+TVJF5Rdk0+5xOuw2qLyHfk7e7x/6OrIeEPCKoT2btw7SjpEoA=="
-
-[[package]]
-name = "iana-etc"
-version = "20230803-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/i/iana-etc/iana-etc-20230803-1-any.pkg.tar.zst"
-sha256 = "c841ba985e02663d9d37df08718639c94f0d6f878a67931d20b8d4fdb2353dfc"
-signature = "iQEzBAABCAAdFiEE5JnHn1PJalTlcv7hwGCGM3xQdz4FAmTLqnAACgkQwGCGM3xQdz4+xwgAlpkqYxZLpdts3WAi34V/eEQmqgnV2SoaeUvyIG6zly4GMLHbJbXJbmu/gN6MTlCc11sFGyJhA1MspLOs4WDyeQTmMzGQKgC+5YaI11mZR52YNzSXjEN8UuxA6cvK704gZbcaBS8D5+FeS7fG8oVbbUWLAv5JCsvP0I7aLKTlAx1tKuaKS01fsfAOI71sBI4Y36mhyHNRhD7jsXPWRGf0KcSVZqrrIsIYwlFsDAFDQa/d77Y4NgaRS0NyX4I019Ubv5rRQbR5yCKngd2732d03mlQoG6EzkHCkRXD9bU0XU0eDx9UCwuYZhrDjrI8uylpA0duKL3+9IomSycjncs7JQ=="
-
-[[package]]
 name = "jansson"
 version = "2.14-2"
 system = "archlinux"
@@ -154,60 +66,20 @@ sha256 = "de45a1cfa23faf16681b9809c4dd375549268b19dd37fe23f96ef8717ac35095"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmJyQS8ACgkQek52CV2KUuSqUwf9H9g/0lroLE8fHR7G3Dcy4OILPGZPkt5HOiJBYdnhi0eWJyetHRCSFsMWiZk9HUJHoVbZH28Z3F75UQfI3cWAThSz1HzUMGvEWF/uTpOKENiwY4egQ0pA88eX6kvTt0BuCLA6JZso6VBz2kzYue4uV/B6otdStx6wf6AfDAIha1jWTButBv/pxpAcTJOp157S4Y+NO59NSn672iTm9CQxWcSSo6Bxfimu86kjceXTj/HK+aZ1onjnD7jtOjsrQOBO63thwouju8yNyD/yjeXzOw5KgsZ4c7gu0Wg10MlcM79G2EYXWFbq5/ARxBkEd49fYhDWaPriGz8bO9ri41vGUw=="
 
 [[package]]
-name = "json-c"
-version = "0.17-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/j/json-c/json-c-0.17-1-x86_64.pkg.tar.zst"
-sha256 = "fd4716d60ac5bf7961aa07c9e63b9bd317d3a2be3b88db57d5f2c8f1f1c2167a"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZN1WYxUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8coswD+P7MnDLKmZCB5Ui2+9Jac0YXC+OsoGzMx+wm3HQdTBPoBAOODlHBaMhAn/sMbx3I9tWtgv3cTgmQaCsUptA4n+UsC"
-
-[[package]]
-name = "kbd"
-version = "2.6.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/k/kbd/kbd-2.6.2-1-x86_64.pkg.tar.zst"
-sha256 = "1646675f85a262a742d455eff2f7e8b16f7d15224e73acfdc2990bd559902713"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmTb1Y8ACgkQdx32Yn7faB/N2Af9E/NBIONAexX6CyCfgOtoylodUA1GDddJPHDPB2pLidCNiMe2Vu9KVdDaAnCjJtFTFUYskBYK16G4FShiYKYrETveLjTN/dWc0BETkgtabynKnr0wJbsJIMCQs7Y6LSgL6eMoJ2ZMX1RIT58ltw+l4km9zu53jeZFpVWRHXoQGDOvvuhcn5a4QElCS/RE3A3CkuXU/DDwPCnWN+e+TWdtQxqpy2GmwdDaPbgjZUhx5cDQjB7NTf0SzVGKg1k17x2dOQ1Z2d6K4mt2yhrSP2rAQd3twsR5C0Kq2Yqww4lhfgqfow+mNhSO1FA/U4+yAw4Re8vpYqo7Rx3wkfRAcKxszg=="
-
-[[package]]
-name = "less"
-version = "1:643-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/less/less-1:643-1-x86_64.pkg.tar.zst"
-sha256 = "aae0ee2cac7ef0072ed6485be1da7dc4d3cc6133e62776b1ad5878e70b9576f4"
-signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZNkPJgAKCRDluymEcK1OQRy7AP9gFinh/AlRaXm+x1PClNEO+vLRcgnP6nLtb6jHfGMQHgEAw7SbyKHfOcES7K4kf0b/gHaSs6C5/x0U+/OC4O1R8gI="
-
-[[package]]
 name = "libarchive"
-version = "3.7.1-1"
+version = "3.7.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libarchive/libarchive-3.7.1-1-x86_64.pkg.tar.zst"
-sha256 = "45a349269935d77bafcd06e2eb40189a44c34cc5a8e3b18723fff0f24265783a"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZMVyZAAKCRBtQr3RFuAGj838AQDIvKjbfFO7spRDeC1wa6apKxgZWFhW/3Abh4TOW//KVQEAmLRmxFw8WvszRRGnyi/Nga8D1y4Q94ho8nVc/vevuQQ="
-
-[[package]]
-name = "libbpf"
-version = "1.2.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libbpf/libbpf-1.2.2-1-x86_64.pkg.tar.zst"
-sha256 = "4fac3eb81e78aadc86861c7a09a0e7b16db2ffb019cc58ead1f97b64a8d4da52"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmSuQ4EACgkQek52CV2KUuSezAf/QUjML1JBbeQ7iHISEinbQ4f7zPJPGQHvPQZlu5yHlKew7yS6F7BPPm5bK8BCJ9xK4wENuMXvjdwxbNMMTPJPRUXJV/JqGjJVbnu1CacrvF0jmfCUoEZfbe64ZzCmgZFSev7UOxgl2EhwoWqDwdH2GmbEb/wEurv4FMio+/+31sQsFKhvz2KWl+ugJSea8RXCeQQyTKcZVYXeRgMzoaZzFruFLgvw2mgkGZ7p5ut0z20iDSQCFKOHiMq/qoj/MV1Fy3UGS4caqBCUitGdY4PwVdzFxoe2WFcheWrkapeYn6wU5UVM8vuMieAX1mMq4bCJBUT8McD8Hyk3wpKwtd80VA=="
+url = "https://archive.archlinux.org/packages/l/libarchive/libarchive-3.7.2-1-x86_64.pkg.tar.zst"
+sha256 = "be399b03fe71b8e50ac2346c922666692fcc776314569588da5205f9f814125f"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZQALfwAKCRBtQr3RFuAGj/XUAQDuVv4LTQ879XVRj+XBJ7niK0NMrvs3yKbJotBA7L1aywEA+tKqqwcWcJow54Y63Rt9gyFIgHtJT+2T3F3a+1/h3Qk="
 
 [[package]]
 name = "libedit"
-version = "20221030_3.1-1"
+version = "20230828_3.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libedit/libedit-20221030_3.1-1-x86_64.pkg.tar.zst"
-sha256 = "4d6c079024014b5683fef2ed27f82b3c0ca066bba52d4817446ce8161b89f69c"
-signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmP45h8ACgkQ/BtUfI2BcsixEhAAm17WTFd0KfIioFmLRtJCHD0w9Dk73Wtfo9dMDX2UEkotFhwvnbaEehYmaVIUQKH05dm8c7mAH/USTZxPU0IknBIgX6cy9t9rHsKND87FkgzmvLvJaryoV7UKCAwWKinAKxjjixJvIav+/3aNFf6DflMp1jW3zxRy+71c71bc45NQ3tYg3t4/1ChtZ+y/Gf4SplJlzWRZ0pI9qh2EAUJ2gdG7hnecHc+bEwRxCtte5CxqgAT+axrred1Ko49ZSmvWK835DRHWOfYghKEA2Dxh3gdLgy/5Qv1wykRgQ/O3ZVeCzprBtI1xpJIy3dasuRne3FTvBBCtYipE/id1wx2hrj4kkw1U0QXyGYkjvIDHzMuIH7uG7DA9fZ2f6ufWpBx3LhugamB3tnMw4VmoCxxBkMEtSWozX+ZLr9IdyXR3JEcHxhAVZdVGAT6pEQmVU70/9ZJsUPK7ZRsDjhYgteU1Dq7MMq1py43jIEe5Pj6r1xrDi4QfD+O6ID/SCPlKuiVpsJXLuTCK2Si1MXucN+R+AbNFO0Y/WoQzBEB0/P+hp/isHtI1lgwP9ETx7qJpP2pFeoVqy/YuJDhv0hU7Jr9pOorjYeTVhLiw7MfWr7ySmqkGmLQR1gESYDV2E3ACKGYnSlZ3+sA8YypZvLHCsQ87Vw7geNUKG839RIVSfeQsqiM="
-
-[[package]]
-name = "libelf"
-version = "0.189-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libelf/libelf-0.189-3-x86_64.pkg.tar.zst"
-sha256 = "4e515e410f2ba7814043ab4a25dd4b93b040408cc69503c60fd4e33e2cc0edf3"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMpLsV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaClJZAP4n+YyxUN1YrNlV77DP6PSHTY6Br2KIBxeHyfA7iYo1RgEAmIhiAWEb0wAz9Es42WbX30gzMKv4ZfsCXkNHA8W1GQY="
+url = "https://archive.archlinux.org/packages/l/libedit/libedit-20230828_3.1-1-x86_64.pkg.tar.zst"
+sha256 = "e41d9f9d4787ecdf58e451e63b5f74dd17854d5065011f8d094994b9fd458b8c"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmTwa38ACgkQek52CV2KUuTLWwf+OHcEEwEzr6+rbSMmIvuyxuYZ656pvt42P2cgGIHdlGRJEYNJtOnP3hKcD8shJzgSRNNSxHxe3385088pcSWdBd1X8aSxa2iBFrT09iAdfh7IgZE/doQmuXKuFP+sN+T0o+vTlS2QPFFymS7hax7miiThrZvzxZsxCRhbXsxf3/bW+9Z+/E/Zkk+dFR5Oj3aPLbgyNtyfCon8eyPmXg4vGgWUCowms14kiO8WT4OA5RE3UYBhnRpO5DOoIfbshoUqcXh9/3QMJoveiBdaQmbkGARSORivYednCk6kenMlEzS0ej01lqvgz4PMdZ+xPYQSe3YYebqFr55Z6+iipGjE8g=="
 
 [[package]]
 name = "libisl"
@@ -218,68 +90,12 @@ sha256 = "b6f495748d9c877c15e47e9691e09d86139cd234e1990a97c531d8d8c9f993b3"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZCq2IV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkzKAQCFNdVbwWwjQ8+Ba+iGYklKxxlcAJoUXYPsy1OChLCUpwD+KsxGh2JyiO1aP5WOmsDBRXhqNB07z3dNBVwNL6GwNww="
 
 [[package]]
-name = "libldap"
-version = "2.6.6-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libldap/libldap-2.6.6-1-x86_64.pkg.tar.zst"
-sha256 = "9b5f8d8fb5e326e5502fe7a5cf46f47e0e2f6a8f0d4cdd9285de2bb5f4cc60fd"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMg04F8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCvAJAQD5Qq+gpBAm3uikxCf4e7q4i9g59+3Nij/Ywxt/ezEq9AD/Rq5squhhvxY8DaUQ1gnptVsMgFmvgZwkFKD7b6lBAwk="
-
-[[package]]
 name = "libmpc"
 version = "1.3.1-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-1-x86_64.pkg.tar.zst"
 sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
-
-[[package]]
-name = "libnftnl"
-version = "1.2.6-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libnftnl/libnftnl-1.2.6-1-x86_64.pkg.tar.zst"
-sha256 = "7a1756a26ec062d051d081d60e8dc9bfd9263d4fd5b2ecaaf1092356d788243b"
-signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZMGObAAKCRDluymEcK1OQYNgAQD9K9QerwGTw07xPUO+w+HC5fbMOfWIIIWQBgnOmhIS9gD/QCC2zr6J807yqzDUdsbZo4vNdR3ONWn8k4QOyQdEJQ4="
-
-[[package]]
-name = "libsecret"
-version = "0.21.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libsecret/libsecret-0.21.0-1-x86_64.pkg.tar.zst"
-sha256 = "86d849a17423384986f60625edd95815a3a75bb79bb7783ec5f863bf0a1619b5"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZNVr3hUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8eUUwD/e1DDq2T0o3gxt8IMgVUmqMVma7QEfYGGWqWHV2n2j1sBAIXFgi85T+Z6GkDlpPQ7gfZLHIOfpSiFePWFVEphMVYN"
-
-[[package]]
-name = "libsysprof-capture"
-version = "3.48.0-4"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libsysprof-capture/libsysprof-capture-3.48.0-4-x86_64.pkg.tar.zst"
-sha256 = "afdecbe78e4214421e343eac2888784cb2a43cc1838a28686e6dff96a14da5cf"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMpKGV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCqfkAQCd9gPE8PUWDwoEGEMfB/LEJB/H54zIaCONDSiX6s6Z9gD5AV+WnpquGv54nP0cE9nlNuGXiFw3lj3tmrh5oMgPKQo="
-
-[[package]]
-name = "libxml2"
-version = "2.11.5-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.11.5-1-x86_64.pkg.tar.zst"
-sha256 = "86f75735ed68ea7495687560b850c2f5d3f369f5277283861182ed8c04b6b780"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZNO5SBUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8eHzgEAyglj11Z3oMKUPCH0s56YcaXMJ2hfUyKQ1iFY44JOCeIBALCcqoNFri1qNInH3dzWfNjlbsmZMU0s9cQ8BVSS/bYB"
-
-[[package]]
-name = "licenses"
-version = "20230729-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/licenses/licenses-20230729-1-any.pkg.tar.zst"
-sha256 = "0c7f90edf074a40697f8c8544c0c6e932652f27c0f2d8cac1e986f9041cc35e1"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZMZOlAAKCRATmwnaW/DTOAIpAQCNqccRY6pm1svwyKkrgKQLDC7yPmIIl0/IyZl0bTHl8AD/Ur9VloLPnoQ/d2NN0QO22lsWNK9b7ewl/aHH/FrQUQ8="
-
-[[package]]
-name = "linux-api-headers"
-version = "6.4-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/linux-api-headers/linux-api-headers-6.4-1-any.pkg.tar.zst"
-sha256 = "93d28caeeacfcb6a93e5b1fc302b404f8a3b28a700fee675469125237cc85d44"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMZ9Q18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCpkWAP0Sp8VVHIjFGF2FVlY9WrqnSQPqXxuHbZlQI2impL/7aAD9E5XrM86uq0nhKIoL1P3O+4ByiIz1kNT65JB4or6moAs="
 
 [[package]]
 name = "llvm-libs"
@@ -298,14 +114,6 @@ sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
 signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
 
 [[package]]
-name = "mpfr"
-version = "4.2.1-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/mpfr/mpfr-4.2.1-1-x86_64.pkg.tar.zst"
-sha256 = "29380ccc401204b20aa00da6e9d4ae01bfd90eefeb70f4ba872d401fa3f7d70e"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZOWwkwAKCRATmwnaW/DTOA9gAP9lFt+4nOS3ykwd+zd8HWj3VkBRGUQalLW2G+B7jsx8RgD9H0X9RXn00f3dAoDdI1WenOz4bxAXZAg0bwLCpfrAeAo="
-
-[[package]]
 name = "musl"
 version = "1.2.4-1"
 system = "archlinux"
@@ -314,20 +122,12 @@ sha256 = "f585ddabdfde5a29b88193827ccc597f74feb878723da9ce813d882c956e19b0"
 signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmRRZ5gXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1VGhAAwoRqJgoycDFQInlZtrXoreYRhFdIJhknGCtsAWgGvYY5CDrEXQwUR3zHpYahzka6CbAv8aZdL67CIZELQ55f22xFyAIyeBLGl21QsI/A3Isom9+IVrOOsIc1+Z5LNp1LTZkAPiK1j06NWkaRpzL6NaFeUf2ziq8q/3lDfXaalyTmy6hV29ZMp8Gsa0gcsCtremCNJXVRwOB5/Hs9a0YJwOheNHuqEc6Md08N5rrE+HkTxMJB62FZn9ta1UqpejnvLBr5Q5yNKFsDuc67ZY6AIBlS/x2iyPDidvzbULj+5fs+4wllkK0svUCUHcKjBjFazCMX+bzS80EymuyzB4dkPxAxJ2/RVsXvFkhquKzAcFEOyZ/CiJiaRfeTZHzcmA1u6tjcl2wopc886wJgX08YqJrlXNQ5jbgo3jkHCUWlVYau7IF9pb+cekgPX6ut+n4ZzZUbaP0yahmzZq5gPsdHf0uKQoVjgxxGhWz6mrllpy/EeKVks0bj/fiHE9Czn0naLoaO5Y5ww25lg3DrAW3GfgTepRW0aXEoecDM9izGkw8D+BqUyV79z7qE5El/ndymyL8dOxzIFIMNFJePzg2E/Av7inXMV3H6gFs6Tw/LmbzQVi/RRO6k4Bill3Md9udh+0waEa70Gs9n2dxNN4C8R1ubeA2yDzQim0ua8caOmT0="
 
 [[package]]
-name = "openssl"
-version = "3.1.2-1"
+name = "procps-ng"
+version = "4.0.4-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.1.2-1-x86_64.pkg.tar.zst"
-sha256 = "a72d3bad500752b03b154e4f93fe3d809a4081d72c571c4d67c7c911bd2f2f6f"
-signature = "iHUEABYIAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCZMkgUAAKCRB2pe+QVESaXL97APwL52jcwCSn8YjpE4OxiU+qYvu5Kk4EmE5ynPhuNAvPnQD/Ym7uBtyg7W9TVIJTMZjbn8cG7laUZ8v4dJSZFKlpfAo="
-
-[[package]]
-name = "pacman-mirrorlist"
-version = "20230820-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/pacman-mirrorlist/pacman-mirrorlist-20230820-1-any.pkg.tar.zst"
-sha256 = "629077253f91ff076eb17f49339a014e889c4cf7fac27b900e75dc1fd285def3"
-signature = "iQIzBAABCgAdFiEEz6avFeXHQUn8HYwIbRZVwUzhwT4FAmTiIKQACgkQbRZVwUzhwT7MUw//crEda9o2IFSfTsRd6qzsSNaksB39fmKGPG/yJPVaFYgmRPMXG3ah30IOHD8QoltXyq+yDOHAaVRQsSsawDwOwiO0Dd01pz+fne6yfo5lf+hiW4y18NGOgb34G3SN2MZ4ecuJLzasy8owIV4VLOSRlvuHvz/2PtGCKfnmtZBjstFNZE1bSg3gE+QfOjUHo4t3CfpSwa9jVqgQ0XlXV5ji8kgvdPqSsvFfgss7nvw7sp1AZKvR2aXk0y1v3JNKs12ku4QyUp0WXYFXbBYwAx4Pt2ewpn7tL7/2H11qnfxb/pau7GT0/Zfw9Txe0K34gEVg9YaxSPEh0ac0rzkyHl0Jj9GUJUAw6der0fWIOl9OY2Z+tdQk+kaaKqHUdqh9nCLZIaUOydI+5vfENaTnqy4RNRQ9WO3QbDV1oc2CP42IFiMWZWoP4nO+16aAapsDDLjuKb/BOrO4KnTDfB3XV9LI+qvrklnsCx74pgtc1q6Wt5dBIc2SgouWZfvXMI0INqkMCxpxtS7Ue+Fgdf5BtUZX1upYjDOrsDhGIZHCjI/L96EwpL1Z8yNBze8q6bBZdAsFMDEs2bUwfb5ryiRH3L2pMqgbUmyh6OLcT1XKuI6xjeHs3kBACmcx9ZDtXdGMfKKr4kDvSLN5PwsbQdTIGcQsFgGcWumgQKuJvb4MX3K5ChU="
+url = "https://archive.archlinux.org/packages/p/procps-ng/procps-ng-4.0.4-2-x86_64.pkg.tar.zst"
+sha256 = "21d06f13c56d73a3b431dce89650512a9dd9a1506513e9ed21989bb8c5a8cd6e"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZQgW2AAKCRBtQr3RFuAGj9RcAP4lcOFt4/NQGxBAJ+dzCP0/JyycQhFzNdbwD6zLHf5zhAD/WY0zZiN13GNoUfsCa35sZfSd9/zHND25Aj9AG2OzyAg="
 
 [[package]]
 name = "rust"
@@ -346,73 +146,41 @@ sha256 = "7e12a0ee39b9aff7b29001707dbcc3b14bbd4a76465f33c2e2cc53f576d21de8"
 signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZOeKDRUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8fhkQEAlgC+zx9+6AghtuA+ou1OyV3+WNLAYTiDZPNwpMBj1XQA/ievy4teuWWRiQmL+Te82gD4TJthIA9QnkKvn+1TePYF"
 
 [[package]]
-name = "sqlite"
-version = "3.43.0-1"
+name = "shadow"
+version = "4.13-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.43.0-1-x86_64.pkg.tar.zst"
-sha256 = "d4a9813ab8deefb2b6ee57618f3b4fa8a8f7239abc962a719729cc14235da11f"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmTnhm4ACgkQlGV6sg8qCSteLggAkum0JqzoVJfIdBUr4zJJqt49sP/b3a8aP9VHOXQlOuvqK9K2sI87ZS526h+NtDz8q5AtM08qavprPKFBNmphPqzd8NbZNsCp3Yu99sOOQtrA1sR9HkLqG/bGyGuCZCt7+bjoBEWfePnvFnlIkIhPoqhF/otkhXGdsddWE9gZoLgFexd9opmWWLIV7xlkNPpZ2p9xOO6LhD0689LFJTEftdfsp9kb8PRqVW4w0erxg8wAn/FpzHx0WBfaMgJ51hLVB3VdDRmw1776sXXhGXWKn2LkkuXJ1POOxypOMbnrQxrmfEDYYtoTEGEz6ZCaNoChPavIu99fDZ2XX31kvbrv4g=="
+url = "https://archive.archlinux.org/packages/s/shadow/shadow-4.13-3-x86_64.pkg.tar.zst"
+sha256 = "0ecc6f07eef7d5a322509b632a15137e44e58600109948cb82f8c2fab8abb55d"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZPNr9QAKCRCbeih9mi7GCL0eAP9w6IC/BXIhnFmr4IBC5qqFHgPSVzzIXZpg03E6657t7wD7BGv5/TpeCFS/fP6ZOL+X5smBydPohsh++/xJhoJXEAY="
+
+[[package]]
+name = "sqlite"
+version = "3.43.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.43.1-1-x86_64.pkg.tar.zst"
+sha256 = "accac976ced67e3bf412c80e067b90afdd6c13df994904b79ba79bcdb361d218"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmT/UvUACgkQlGV6sg8qCSstvwgAht980c/6owsDFaDBGny9TtducOtXYSwua8LEEYB68S42JE8e6yZe6EtqQDv3UbR6Yx0zwrSvPEt+WhQMUVRbCi4YCjbZZ2OB3V7H0BZXBNxspSDbNxXrq+OtcXbkK+ehg9iNvpyiYhHFBpEWhIM3FKFBgPsAAeMBlSu246Zc+lteaKDknW3M9VDH7QPn8bhlOmC48e5n3JiL6c8/5XruxNwnaPYguIXMMKAvmmulMCSXyRLTo7vc0GdKp/LtGXmzvB3Hs4xDoMkPOFOJ9wiNCKeHeHV9voIwyoSljibfzcqAkZ7i3/AfBb9sdGTYO/NCgw4ybsJNap0QKWuRYcIaMA=="
 
 [[package]]
 name = "systemd"
-version = "254.1-1"
+version = "254.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/s/systemd/systemd-254.1-1-x86_64.pkg.tar.zst"
-sha256 = "52b8f807841b7df7d865ea838969165e7f05b06869435fc37762652ca269adfc"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNOe5AAKCRBtQr3RFuAGj/VhAPwNuOhzKRPYlPvHFX6GlODMLHhQcQjBUxHjnwfxFaTJaAEA8pedTxMGVTbOpr9X48Qp0s7YdNwH8Lzl2s8OJhELMAg="
+url = "https://archive.archlinux.org/packages/s/systemd/systemd-254.3-1-x86_64.pkg.tar.zst"
+sha256 = "80d1b2f6270ed78a133ec726673346c6b09255aa3aa6f5b203b9b1481f1d6f7c"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZPzU6QAKCRBtQr3RFuAGjwmpAQDukF+RLCG5gCZQ28D809V+Oap70mG4s7Cg19lvmOvLaAEA+LAbk7xpxRJmn/MStReCrHTQ92JHO/7Rl/2B1qR4WQE="
 
 [[package]]
 name = "systemd-libs"
-version = "254.1-1"
+version = "254.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-254.1-1-x86_64.pkg.tar.zst"
-sha256 = "2691d25b17372d8c364f797762ffa20ff41032ed201752b2d9afb4f924f8b5b8"
-signature = "iHQEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNOe5AAKCRBtQr3RFuAGjzJgAPd+Unhwy7CFUfyBBIxa6gOt6WLBL4Q2o4AqGJJkR9BpAQCv9ZtQ09LhZf4ema/Ex8s9l4xYOYnZ3zRsnet993ChCA=="
+url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-254.3-1-x86_64.pkg.tar.zst"
+sha256 = "2354d1f1fe85568409257ffa0fb63f75b72866823da9731d9da0556fbe6a221c"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZPzU6QAKCRBtQr3RFuAGj2ZEAP4g5s/+lOJQ9PiNymuqPtjmWNOo16eJ8iXHZc0WSH/HJQD/bxwvEraxHIy49c+tyw0uLs/Vq3PqnG8at4/CF7s8Uww="
 
 [[package]]
 name = "systemd-sysvcompat"
-version = "254.1-1"
+version = "254.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-254.1-1-x86_64.pkg.tar.zst"
-sha256 = "a1b1d78b43fffae993d8cfd40976df2c83402083b9590d523839f535a73a9109"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZNOe5AAKCRBtQr3RFuAGj4LqAQC/q5mr8lgdHxjwP8R6NR7gCZlGBvpGtamBW3O9dintRQEAom0Niy7wfyWlOlsl+V+lA4Myf4oPHYE4q81IGC/+CgI="
-
-[[package]]
-name = "tar"
-version = "1.35-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/t/tar/tar-1.35-1-x86_64.pkg.tar.zst"
-sha256 = "c4103c42ae8825ca9c679cb23e088e750c0df67aaa02e6e0164fc198f44c61ae"
-signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZMAT8wAKCRDluymEcK1OQT0pAP9/E2Wsq+dPo0gG/rPJGdNK/9OomXskc2I2ktEs5TbEnAEAwGV/vG0bpqh2+I7+x0UEbPcbKdVpkPT8UL7wK4k1QQM="
-
-[[package]]
-name = "util-linux"
-version = "2.39.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/u/util-linux/util-linux-2.39.2-1-x86_64.pkg.tar.zst"
-sha256 = "1cc8c68961d2768211dfb8462eed70484a83e4e0ef720f483f224aec4e005de9"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZN3uggAKCRBtQr3RFuAGj5fqAP49YRjF93QI52v6QtOXxG4CErwC5gFvRu5C4FiU1GQqaAEAsA2N1XIxs1mILcM6i5dodXGWi+09HGGuzAzbQ0motgs="
-
-[[package]]
-name = "util-linux-libs"
-version = "2.39.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/u/util-linux-libs/util-linux-libs-2.39.2-1-x86_64.pkg.tar.zst"
-sha256 = "96cafced0e65318cb17fff749a55c486df660f38407187aa2f50df179aa38fd1"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZN3uggAKCRBtQr3RFuAGj887AQDgmLTwNi5Up5byJOAVlRuCWyny58LS2M7Gh/m4XkP8GQD/TkynC7YZhezIkmPQqxPyB0Z0JUG21/rpn16fHdU8HQk="
-
-[[package]]
-name = "xz"
-version = "5.4.4-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/x/xz/xz-5.4.4-1-x86_64.pkg.tar.zst"
-sha256 = "cdda098368bcb508bbce77bb41ef5930ece769d440eac2350e8ae7f4607d81be"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZMq2IwAKCRBtQr3RFuAGj/PQAQCFBotlapDBNzZslbJs6ejiRwuiHnaCwa0cwQyiPh9TaAD+JEVZuixvbYCc2DNtxO3cNqvKBMz4lTFzxBGHuZ70wwA="
-
-[[package]]
-name = "zlib"
-version = "1:1.3-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/z/zlib/zlib-1:1.3-1-x86_64.pkg.tar.zst"
-sha256 = "8a9b1e5e354197828e74860b846a951cd981833d1b07ae182a539b0524b6ef3a"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZOJANQAKCRATmwnaW/DTOLH2AP438CJVUrT2M0up+mcpoepk97VYMDdtPMIiS6lX4e7t7QEA5rJF9Yp5dS2qpnRLlTUdMVhSPAxrqGEq27U5ZzeUHA0="
+url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-254.3-1-x86_64.pkg.tar.zst"
+sha256 = "c9827ae58fa6ee27a8bb842c82d187252baf6706dcf69eec66bfa7361d50e2c8"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZPzU6QAKCRBtQr3RFuAGj0uRAQCmQr/cuIBblrOtD+lsjsSfPGmeQaZMagRAF/0SLqz0dQEAoFb9cQnXjdRb7vFUhXL1T7V/awKElcxnZAMOHmw0tQg="

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -34,6 +34,15 @@ pub struct PackageLock {
     pub sha256: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
+    /// If true, this package is already present in the container and does not
+    /// need to be installed. It's only in the lockfile to make the
+    /// repro-env.lock diff easier to read and help git's delta-compression.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub installed: bool,
+}
+
+fn is_false(value: &bool) -> bool {
+    !value
 }
 
 #[cfg(test)]
@@ -57,6 +66,7 @@ mod tests {
                     sha256: "6a3d2acaa396c4bd72fe3f61a3256d881e3fc2cf326113cf331f168e36dd9a3c".to_string(),
                     signature: Some(
 "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZKPPXgAKCRBtQr3RFuAGj9oXAP94RQ1sKD53/RxVYlVEEOjKHvOmrWvDkt1veMYygnlnIgD+MLg/TT6d71kE8F08+JH+EcnG7wQow5Xr/qBo1VPLdgQ=".to_string()),
+                    installed: false,
                 },
                 PackageLock {
                     name: "binutils".to_string(),
@@ -66,6 +76,7 @@ mod tests {
                     sha256: "b65fd16001578e10b602e577a8031cbfffc1164caf47ed9ba00c60d804519430".to_string(),
                     signature: Some(
 "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCge2AQD/LGBeHRaeO8xh4E/bAYfqd1O/OFqk2DrQBJ73cdKl2gD9EC8p4U/cXQK8V774m6LSS50usH5pxcQWEq/H0SF+FgM=".to_string()),
+                    installed: false,
                 }
             ],
         };
@@ -117,6 +128,7 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N
                     url: "https://snapshot.debian.org/archive/debian/20230115T211934Z/pool/main/b/binutils/binutils_2.40-2_amd64.deb".to_string(),
                     sha256: "83c3e20b53e1fbd84d764c3ba27d26a0376e361ae5d7fb37120196934dd87424".to_string(),
                     signature: None,
+                    installed: false,
                 },
                 PackageLock {
                     name: "binutils-common".to_string(),
@@ -125,6 +137,7 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N
                     url: "https://snapshot.debian.org/archive/debian/20230115T211934Z/pool/main/b/binutils/binutils-common_2.40-2_amd64.deb".to_string(),
                     sha256: "ab314134f43a0891a48f69a9bc33d825da748fa5e0ba2bebb7a5c491b026f1a0".to_string(),
                     signature: None,
+                    installed: false,
                 }
             ],
         };

--- a/src/resolver/archlinux.rs
+++ b/src/resolver/archlinux.rs
@@ -181,6 +181,7 @@ pub async fn resolve_dependencies(
             url: pkg.archive_url()?,
             sha256: pkg.sha256()?.to_string(),
             signature: Some(pkg.signature()?.to_string()),
+            installed: false,
         });
     }
 

--- a/src/resolver/debian.rs
+++ b/src/resolver/debian.rs
@@ -252,6 +252,7 @@ pub async fn resolve_dependencies(
             url,
             sha256: package.sha256.to_string(),
             signature: None,
+            installed: false,
         });
     }
 


### PR DESCRIPTION
While using this tool myself I noticed the diffs can get fairly large and confusing to read, this prepares a new flag in `repro-env.lock` so packages can be listed with a documentation purpose/to help with delta compression, but `repro-env build` is not going to attempt to download and install them.

`repro-env update` doesn't write this flag yet, but `repro-env build` needs to understand it early for compatibility reasons.