### PR TITLE
chore: add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Exclude lock file from stats and hide it in diffs
+**/repro-env.lock linguist-generated


### PR DESCRIPTION
Hey! 🐻

I realized the lock files make it quite difficult to review PRs and view diffs so I thought it would be appropriate to exclude them via `.gitattributes` (similar to `Cargo.lock` diffs are not being shown on GitHub).

For more info, see https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
