### PR TITLE
Record provides if used for one of our dependencies, support environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -71,7 +71,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bitflags"
@@ -169,9 +169,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.4.6"
+version = "4.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
+checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.6"
+version = "4.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e231faeaca65ebd1ea3c737966bf858971cd38c3849107aa3ea7de90a804e45"
+checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -191,30 +191,30 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.4.3"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ae8ba90b9d8b007efe66e55e48fb936272f5ca00349b5b0e89877520d35ea7"
+checksum = "bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.2"
+version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "clone-file"
@@ -249,9 +249,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
  "libc",
 ]
@@ -267,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -292,9 +292,20 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "digest"
@@ -324,7 +335,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -344,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
  "humantime",
  "is-terminal",
@@ -363,12 +374,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -385,7 +396,7 @@ checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -397,7 +408,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall 0.3.5",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -418,62 +429,62 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -498,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "libc",
@@ -509,15 +520,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
 dependencies = [
  "bytes",
  "fnv",
@@ -525,7 +536,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -534,15 +545,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -564,9 +569,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -619,7 +624,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -628,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http",
@@ -642,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -652,29 +657,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -684,7 +679,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -695,24 +690,35 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+
+[[package]]
+name = "libredox"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "log"
@@ -762,13 +768,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -838,9 +844,9 @@ checksum = "978122cdc72f39ed3c6343907453570570699169aace43dd09d46b52cc5f681d"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -856,9 +862,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -874,15 +880,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -891,13 +888,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "redox_syscall 0.2.16",
+ "libredox",
  "thiserror",
 ]
 
@@ -1010,17 +1016,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "684d5e6e18f669ccebf64a92236bb7db9a34f07be010e3627368182027180866"
 dependencies = [
  "cc",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1031,22 +1036,22 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.38.19"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745ecfa778e66b2b63c88a61cb36e0eea109e803b0b86bf9879fbc77c70e86ed"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.7"
+version = "0.21.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
 dependencies = [
  "log",
  "ring",
@@ -1068,18 +1073,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.6"
+version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
  "untrusted",
@@ -1087,12 +1092,12 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3ffab8f9715a0d455df4bbb9d21e91135aab3cd3ca187af0cd0c3c3f868fdc"
+checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "thiserror-core",
+ "derive_more",
  "twox-hash",
 ]
 
@@ -1108,14 +1113,14 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
@@ -1146,29 +1151,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1177,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -1238,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -1248,19 +1253,19 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "static_assertions"
@@ -1287,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1330,64 +1335,44 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.8.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall 0.4.1",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
-name = "thiserror-core"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d97345f6437bb2004cd58819d8a9ef8e36cdd7661c2abc4bbde0a7c40d9f497"
-dependencies = [
- "thiserror-core-impl",
-]
-
-[[package]]
-name = "thiserror-core-impl"
-version = "1.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1407,9 +1392,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1418,20 +1403,20 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1458,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1472,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1484,20 +1469,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1512,9 +1497,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1574,15 +1559,15 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1624,9 +1609,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1634,24 +1619,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1661,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1671,22 +1656,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wasm-streams"
@@ -1703,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1748,7 +1733,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1757,13 +1751,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -1773,10 +1782,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1785,10 +1806,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1797,10 +1830,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1809,10 +1854,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "winnow"
-version = "0.5.17"
+name = "windows_x86_64_msvc"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b801d0e0a6726477cc207f60162da452f3a95adb368399bef20a946e06f65c"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -1824,7 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -952,6 +953,7 @@ dependencies = [
  "fd-lock",
  "flate2",
  "hex",
+ "indexmap",
  "log",
  "lz4_flex",
  "lzma-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ memchr = "2.5.0"
 nix = { version = "0.27", default-features = false, features = ["sched"] }
 peekread = "0.1.1"
 reqwest = { version = "0.11.18", features = ["rustls-tls-native-roots", "tokio-socks", "stream"], default-features = false }
-ruzstd = "0.4.0"
+ruzstd = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha1 = "0.10.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ env_logger = "0.10"
 fd-lock = "4.0.0"
 flate2 = "1.0.26"
 hex = "0.4.3"
+indexmap = { version = "2.1.0", features = ["serde"] }
 log = "0.4.19"
 lz4_flex = "0.11.1"
 lzma-rs = "0.3.0"

--- a/docs/repro-env.1.scd
+++ b/docs/repro-env.1.scd
@@ -47,6 +47,9 @@ This command loads a *repro-env.lock*, sets up the environment it describes in a
 *-k*, *--keep*
 	Do not delete the build container, wait for ctrl-c
 
+*-e* _env_, **--env** _env_
+	Pass environment variables into the build container (FOO=bar or just FOO to lookup the value)
+
 # PACKAGES: ARCH LINUX
 
 Arch Linux hosts a comprehensive collection of recent compilers at https://archive.archlinux.org. You can create a *[packages]* section in your *repro-env.toml* with *system = "archlinux"* to install additional packages with pacman.

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,21 +1,21 @@
 [container]
-image = "docker.io/library/archlinux@sha256:99807b5ce1017b5072f5c028d0209e97e3ab0341368880c05f3e4438ed1be5f1"
+image = "docker.io/library/archlinux@sha256:1f83ba0580a15cd6ad1d02d62ad432ddc940f53f07d0e39c8982d6c9c74e53e0"
 
 [[package]]
 name = "archlinux-keyring"
-version = "20231012-1"
+version = "20231113-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20231012-1-any.pkg.tar.zst"
-sha256 = "d98274653963b6a6d3d9f4498c9b29894395fd892db03b97c5a11cdb999465b5"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZSeQSwAKCRBtQr3RFuAGj3wkAP4iCJsUcNdZjJSd2nW+myyscixkAkIAYyQUjPSOzS7dVgD+KXZciERFtfkdv6SsK3EqmdAZwF3wA2gv/M/dE4/mHg4="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20231113-1-any.pkg.tar.zst"
+sha256 = "3f0a96b6e52f6a5472d1553db19ea1a1a8a294982925d85676a5b999550ea2ff"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZVHqWQAKCRBtQr3RFuAGj1XdAQCbDtDyRsBJh8Qa0G2obUxLdcwvtnEJb1xJfnArR2OnhAEA/S5hfxs9ZYo4y5bsxxUzL7yNiPxAcwrMQbe+DbjJgQY="
 
 [[package]]
-name = "base"
-version = "3-2"
+name = "bash"
+version = "5.2.021-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/b/base/base-3-2-any.pkg.tar.zst"
-sha256 = "25da12f0347e4bef6c215dcd32b6495beb86010a8c7e40828167b95f56639061"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZSIDFBUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8ejAAEAtnDSI0OslAAJZP5UxL3lPSvlE/X6+J3PLjBH06lWBA8A/2bZk6Fh9gmVXSRxW8Pd/EDkdduDTRyTsPVYh9QswtIB"
+url = "https://archive.archlinux.org/packages/b/bash/bash-5.2.021-1-x86_64.pkg.tar.zst"
+sha256 = "e032825d55074b780840509ec57185b0429bc2e6642261e104e989e4e9b596c2"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmVeHuYACgkQdx32Yn7faB9z+Qf9EGTR2GzyePyL9LEO8XEjCkTQI6UBRvc7+p840DtdfzWUviCtfM31rc+Nzg3qY+8GLfgKeymzsD+KBngurjv1t3zX1Elu9P9Sem801gsywWdQgSUu5xhGPRK+vQPCRFnOYufqICw+BmDhuXQDullC7rEL2zKVngzGAwkn98BfJdYqY25KvEIMtvXlUpvB3tUxU0OPq+tFnUFvBXS6PSp7eXBoy+NDutsXulm8R2e3QmCl+m65P4sDDhR7/JCx69uQB+Uu0oZbWYpT43FsvTsfE4ELJQxstVSKnRhA8eDCXcetnOtK5Qd3a2iasM4IIMrgA4KHM0qgFccIS0jlpeObjg=="
 
 [[package]]
 name = "binutils"
@@ -27,27 +27,11 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZM0fcl8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "ca-certificates-mozilla"
-version = "3.94-1"
+version = "3.95-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.94-1-x86_64.pkg.tar.zst"
-sha256 = "0244dab04b7fba1f09e9a07678f11831e4324c6c08593253e5a69b2c893e2bce"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZRvyFhUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8etYQEAuF3Quef8utiDIH6grnkFa5SKTbyYgCwi7SjIJQeDcioBAKKeebAPgnEI2yJ7KuECYSiz8HX8Aw/i3u6YEvtuQzIA"
-
-[[package]]
-name = "coreutils"
-version = "9.4-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/coreutils/coreutils-9.4-2-x86_64.pkg.tar.zst"
-sha256 = "a524aa262011a992712e2ca7d498c833e8ab1dc547c1bae8a65c27fdc9d3272e"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmUfmNMACgkQdx32Yn7faB/mHggAhCaynuc+/nOfqY2BWnOqQtyhUmdGlfqi2YQ3DAps4osVxJqXcfXu19q/98oUCn56kWjVfBoaUc6hd1OTGbmE7GksiuqHau9AISj3xJm0ZOpEZ2QxdNLs2Y6et02H9NI6uWcD2qW/9/7mOnSqNDWni8QgoqxOgFr2z+Ldr8n1n++fG4HPhofHvJuQ8ETWQ16/vsEee2Vj3ZhDTUENaSr9E9Imknq6XNUHpbZgR7QYGvUJJKfk/uE8O0RfwpCsHXk6CZd/gSDOpdOUf8ofeksJluk7vOidnvBapT9fIaD1fVJ9uA9hATQTnwVQjjW/wPCjt1yL49uTRKEO5YUQtwo6OQ=="
-
-[[package]]
-name = "curl"
-version = "8.4.0-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/curl/curl-8.4.0-2-x86_64.pkg.tar.zst"
-sha256 = "66c6c0ff8e21478ac965f7ff759eaeb917c91722b47a5aa520bd2e751348ad59"
-signature = "iQIzBAABCAAdFiEEtLdZYl1GM0MLdIdwWeQ+EGskc2gFAmUnqlUACgkQWeQ+EGskc2jizQ/+IKFq6qHXVsX529tQ/rOloL64mXFnATM/0QHKIQ/fHz7Ru/Dqxofca8lhwveQoN0YC4XU2gdE0eDZPknv4LjdD+oeAOSmD0Hf9plHaKYinmVJVS8bMSGTNLGwsUprPX60ucfx7xyWPK6rVf5OJrLl4xF75Ofd0wbAwdAouTP5yQUST+b3KdM8joRpJxGTBa/bv8Mp4WQ8zeE3CoggM/5yYXpIVVFDD40eBgGITNC76YuWajeNMhWHGUcbhiO8lZheIs/abOuDb6frxYdarjj3V4UwhYDFRd/BuBRNdW73FzW3aT2JONdt4OyOPIe614yDGG48a4dpECicLgEnpKeBTsg2Z8Wu9Pt5Q3gO1Q6ODipleA21bbKtTL+Rn7R+fRHtRVBdynmF6m2XmDeFi8E6kEP7smXlpn/TSHKxT4olo19fV808llSsb/Ok/ajteVqoCYixSe6KIGYhx3WfxkdKXojeYH+H5ZkqG0S4XCq/rfuHdBN1f1y44NE+rp8+K5157FGgIV3id+EsYLC37+z4Ht42k8qbzuW/HrqmHZBf+TPwRT0848eol2GLdzhOT7H4t3tdqqEG+qtAFDKDd9nFUNaMhYVEJcAA+FbJ+K255TfwS1ki1IrgyluidtQLvJ3F/AIKKm0UqmJvp6ziBAe46ght06x38oYdFf1AAp/P02E="
+url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.95-1-x86_64.pkg.tar.zst"
+sha256 = "9675bafbb2fb3cd60456777c47397c238d335fa15c45e7a9c6a643b964d8f54a"
+signature = "iHUEABYKAB0WIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZVvgaQAKCRA7lKgOUKR3x2bGAQCzVkzLiz8qv3qVAM4HLGldxLeSZOh+8HJ43yP09alIoAEAlE1DkwjpCuAbI64Urxu6/kf93I3OK2Ih5LWshGf8swY="
 
 [[package]]
 name = "gc"
@@ -67,27 +51,19 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZMoUtF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "gettext"
-version = "0.22.3-1"
+version = "0.22.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gettext/gettext-0.22.3-1-x86_64.pkg.tar.zst"
-sha256 = "38c4350e1aff665cc94cfdc62092c9a26abbf21ad2550bed36f56dfab019e075"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmUeS/oACgkQdx32Yn7faB+lPQf+P3DV+4R82OqlddduvSv+SmDtD0VRtnziByM9MDwvvZbkz1gjLnfw6UgG3lCCZ38b844hQ0Mac7wFUbu7vn+JWskveg0inyud+gtNw55aogASiVGCbyNW2AarnzH5DS7WhShY3cyridnpkpHFdx6decmOFiImOj5vGJEx7g70YncqCpywWZCQCl89KWYKY03jZYOyyz1LZIKQTHP7M3YSA9DDU+iCsgZrLp0mkzM+Tq8sG2KjC2uBaMY3FxUVgL/Kuow/B99/xXOcVFCceo8/bvachWZ0xjVp4RgqH6CKsGEoOLFBbzbr4/lSW/mfBZGiVzIH/bAYcD9ceMKB5KrrjA=="
+url = "https://archive.archlinux.org/packages/g/gettext/gettext-0.22.4-1-x86_64.pkg.tar.zst"
+sha256 = "5f5a42559de23b14cd44ff7108c5e39c1adfe2d37a7a83283ed6279c07f16981"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmVbVLsACgkQdx32Yn7faB/lzQf7BqfqObjgvutz7fcU6+vQqzNtzO+mpwuMkTymYi4iQOW+8ybu6peeCjq4olHaUH0VMwvgJa11tne3yvQSs1MDr6a1S0+wUVHu+jRw9Sau/PIh8WiA5Zi5KQRiNySbLmBAly0cwNMgd0E8/FGsR3nieL3yITCZ1o31prKeGcFEriEZ7Cck8VW704ifl+PnSvwFfnYjluNumWD2yKyTnKY3mDTeZXFUk8frsg8GJWzdbE40p+hw+s4Yby14J7sMgLNRzTm7gHlYwG+au2PPKzzlT+Xgoc2jK92Gy5KEcLiBqKufZ55BWwVpGN2vRcm8yEY3gvreBbfZ6GpRYSJn5v8oXQ=="
 
 [[package]]
-name = "glib2"
-version = "2.78.0-3"
+name = "gnutls"
+version = "3.8.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.78.0-3-x86_64.pkg.tar.zst"
-sha256 = "9ef6d5c2cce40e830407385a23552168e29839ed3df70fc6b27588878fcb9a81"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZRzOPhUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8ds9wEApjgvF8AwJzEdez6Jid11Oh4qHlOtRuDNnlyZwibqiTsBAO9er3oRCSTy/d8Gc3C5cSmG8xAFRXoDinYkxp5GoY0L"
-
-[[package]]
-name = "glibc"
-version = "2.38-7"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glibc/glibc-2.38-7-x86_64.pkg.tar.zst"
-sha256 = "539d7e30e38b1061aaab11d20117c9c2743f84819ae7aac1ffc003ec6ee6fe0a"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZRyMUl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmyuAP0Y2rp0FmigzRguCrjwXy+ScnCCh1dCCwLiv16hTuoRBgEArFWjmlTjMx4gH2N5kA+D5iTtwQuUGmT0VHZwBKhvcQI="
+url = "https://archive.archlinux.org/packages/g/gnutls/gnutls-3.8.2-1-x86_64.pkg.tar.zst"
+sha256 = "6a09965211bbea1d52948e80df3bb2bd43690aaa6aec480bf5c4afa7c018e671"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmVVKAEACgkQlGV6sg8qCStcbwgAgdkm0qrL+n+2BwoHubrE3OKRWQ+oVSmyvVLucmBXWaL9rVNcjzFt+5ItWktJ9rY6GWZB+3knv369woUR+CuwkHjn8y69cjzgCdmjsOMQlXjrNQstTmoZfx/yl4dRbDNoBByGQF15vCuWZWMo08ukzmVWbApvhv5pff6hiCBwMk+38HlOPuQpKWsQkqg0G2x3iFynMcNqS+zecaoUMAky3CX4sRhEJmEi/8IJWBuqaGVA58gzkZIUHqQXRnj12IxBcAzad5KGYkbxkAn6Y6W9JO/+NTkCrzrCxsZ+ijWjTbeGs94w2Dzq4NgxWdt+28vrLrGlNdi7ETRDW5sdAZUMEg=="
 
 [[package]]
 name = "guile"
@@ -98,12 +74,20 @@ sha256 = "1c17a7b5c3c9c6ca580c76b36080603587bd2dc39a2c3cb0f07d755da05126ab"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCY9Gy3F8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCt5aAQDMcoBQsIEeLWacejGD+7TLT6F3Nu1Q3KDaNAZojqkwmQEAsvIVi/edva/VSJY9fHvmrcdV7jJrRjqglpWinxuWPQI="
 
 [[package]]
-name = "hwdata"
-version = "0.375-2"
+name = "iana-etc"
+version = "20231117-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/h/hwdata/hwdata-0.375-2-any.pkg.tar.zst"
-sha256 = "b5424ae5671e6028f0a56356fa02e76f2959ce8d0ea20063099634b49d1a9f87"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmUfl4EACgkQdx32Yn7faB8SVwf+NfJ4TdZJpv8AituEDAlfoijMFyaaS1k3zFUcQFb9haIeAYm08hGOX5IH/QSm7jheEge5wMo56vuZ6Ykv/jnDHeQKrI+oti+HTgxOqgljQJoFEoZ0Cx/WNBcUguqYSu8jQJ4VCFFWVN/UCmie4uQrOX2TfaqHixRR8MrQwvz6/T84a3iTAPaZ9zuVSXcjeJX5lfMwtB6CmhmJwn4gBrtcXKIPncvnVtJN7TTbtwi6mVjvOSMfmO5HP7mBxSid0Z3gnlL/LFmEenhh1nNfX1oRCl34k26TD1QNKkXRy/Ml+yFBt2kxI2/LlooEQ7iHVsKucHDj69AePd8U8Lq8I31jgQ=="
+url = "https://archive.archlinux.org/packages/i/iana-etc/iana-etc-20231117-1-any.pkg.tar.zst"
+sha256 = "95d751b80c0dd458db748630ed631e1c8f8ed35ef4cd5e9589d586a312fb4898"
+signature = "iQEzBAABCgAdFiEE5JnHn1PJalTlcv7hwGCGM3xQdz4FAmVaEDEACgkQwGCGM3xQdz6nxwgAps6ZGg+27InB+uFzzJ9ha44HR/aReLOSoBLPLyh/8Xy0Q8b/cPk0XD+6XY1QvB4czDNew0wHymbdeP8SVFYMvd6yuBnL/TWrb+5f4fwkAvM9sMY5hCOYMolRRz5W5+jC/3y2rv0lfBR+bvcAUFS1Iez5vISJnwO0CyG5ohkJhC2KY6d1a/o/aWMrjbQZ7b7GZiBRuTu8FU0Y9V+gyMNiyrAN+AUx3d5A6teezejmzv1gFk/WJddScb/m/OgK5TS2eOMd9MEFGc539Re3E6Kf6GhcWJ0Yo59LPPOo7YNbHa5rMWULket6sZG9UdJz2ElmpiRfAWHZrPrUTxCqqFDlOg=="
+
+[[package]]
+name = "iptables"
+version = "1:1.8.10-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/i/iptables/iptables-1:1.8.10-1-x86_64.pkg.tar.zst"
+sha256 = "260ae5326f3a2c0d3024e764a8a2d6518e9004e978431f7bce89dafab5cc9bd7"
+signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmVR8S8ACgkQeGxj8zDXy5JayQ//Vy3f5q5+3MkxQ1zVWzFiCN8yQBHnu9voa7R9Vcr2rEUZIRlup1/h7oJx6Ef3WAf47focRBzn2Nckn5yCbiATFKqaH7v+bIkAFhcCORi+FyfvdlV8G2jaZF1E6/LnYzSXhssMrhpVD9lY/HaguLDZbmASwRFMD16d9VT1ZGCFhdeD4eb+ERKFzbPltWkFh+Q7+Hr7C5AcWhONnL1ZlpYe3ll3FWQ1ObMz4DTWT3hYuIXpRS4wpQi79z6+v5peZ6UtdNhrH8QjCMYzE04seZMIaiSxep6wNs/gTYz44rvHrgbB3AJhyP3e6r+Jsxv2xrX4PiIz/p7NWe0rdl90//kPa1Xqcol9cH9Htuo+H32FY3TTs4IY6ibp0fxpVhk6I6Cqp5ansBSs6t+t/AeVWRQLtHb8OU2L0WrtnV7dnPza2nC49jQIS3vI5b5AhY9fmt47z6ZNooIylJM1mufsEZNmZNXUBT3Poi6ToU4O81ZxlVUOvApwjbiCUvsKi0WHfFoTW0xJRnybQuhnMpBzIcPF2x27hCT8xeRHzRdfjLHQpRw2+eqsDLbDK+DHU9uTOxHz3WsA5aXTcRtYKpsyhV6m4OLFq6cHSJHG9dYYHUApKCQI6bOCq3xN7PRgUq1gOkH9tDmyKmr8BgniUMzn6B2VdIEaSoOa7ch63eq03qNTAy0="
 
 [[package]]
 name = "jansson"
@@ -114,12 +98,12 @@ sha256 = "de45a1cfa23faf16681b9809c4dd375549268b19dd37fe23f96ef8717ac35095"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmJyQS8ACgkQek52CV2KUuSqUwf9H9g/0lroLE8fHR7G3Dcy4OILPGZPkt5HOiJBYdnhi0eWJyetHRCSFsMWiZk9HUJHoVbZH28Z3F75UQfI3cWAThSz1HzUMGvEWF/uTpOKENiwY4egQ0pA88eX6kvTt0BuCLA6JZso6VBz2kzYue4uV/B6otdStx6wf6AfDAIha1jWTButBv/pxpAcTJOp157S4Y+NO59NSn672iTm9CQxWcSSo6Bxfimu86kjceXTj/HK+aZ1onjnD7jtOjsrQOBO63thwouju8yNyD/yjeXzOw5KgsZ4c7gu0Wg10MlcM79G2EYXWFbq5/ARxBkEd49fYhDWaPriGz8bO9ri41vGUw=="
 
 [[package]]
-name = "kmod"
-version = "31-1"
+name = "libcap"
+version = "2.69-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/k/kmod/kmod-31-1-x86_64.pkg.tar.zst"
-sha256 = "122d5605b51e27cd6fa584a36e3f28a744ff8e7e7ff98581133115d0bd57252a"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZRc5rgAKCRBtQr3RFuAGj1vmAQDyBYKNg0/oDldqTtRcvhu9uioXIO6T6cDz0E0MvvDDpgD/UNxyVQL6+YwgbWauR0qjb/GC4rCXFlqrj9m5sh9xmgM="
+url = "https://archive.archlinux.org/packages/l/libcap/libcap-2.69-2-x86_64.pkg.tar.zst"
+sha256 = "49fd0362aadfc6b389d1c8f4a7260698bd13d88f6295aa745c2de6f24c2b8bd6"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZU/0sAAKCRCbeih9mi7GCFRnAP9QbcX758yN5MGdK4iNGpX9CAe4Ih0GyAwCfKuTqytd/AD+OYCC4MIbvoPQRYt8NXSkM5HQWlqlg5YWaQcyAvCVfQw="
 
 [[package]]
 name = "libedit"
@@ -130,6 +114,14 @@ sha256 = "e41d9f9d4787ecdf58e451e63b5f74dd17854d5065011f8d094994b9fd458b8c"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmTwa38ACgkQek52CV2KUuTLWwf+OHcEEwEzr6+rbSMmIvuyxuYZ656pvt42P2cgGIHdlGRJEYNJtOnP3hKcD8shJzgSRNNSxHxe3385088pcSWdBd1X8aSxa2iBFrT09iAdfh7IgZE/doQmuXKuFP+sN+T0o+vTlS2QPFFymS7hax7miiThrZvzxZsxCRhbXsxf3/bW+9Z+/E/Zkk+dFR5Oj3aPLbgyNtyfCon8eyPmXg4vGgWUCowms14kiO8WT4OA5RE3UYBhnRpO5DOoIfbshoUqcXh9/3QMJoveiBdaQmbkGARSORivYednCk6kenMlEzS0ej01lqvgz4PMdZ+xPYQSe3YYebqFr55Z6+iipGjE8g=="
 
 [[package]]
+name = "libgcrypt"
+version = "1.10.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libgcrypt/libgcrypt-1.10.3-1-x86_64.pkg.tar.zst"
+sha256 = "f058a4ba7c47de8c1a72b035a37139bc4bcad76de524fa4c958fce40a0044e11"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmVVG94ACgkQlGV6sg8qCSsZxwf+OzXCAVUGbQVI/oS9mmFDM9sf4j51074iAzdcKemsd+xuxf8W+l7FxfoznUXUdN7wAGqX4VGL5SPGOBpCEKk/LSyMCsWa+oiUzm+AaLMiVpwqmFq96ylNh9vtavdC2QCLImf89vtN9UkiPVTEwLUt3A0mz7usHk7uTWkMs42PPBzD6GQB5+5ATGRc9p7f4DeTgqVaO0Pk9L5RAOt3wqgmGMqJ2P7IKcbzZ/TKTqLwnwqFEijDrpMTAgwSY9oKLcSf2v22Gd3fLRYvF/SlebDcrmH56k571H4GCx8EgQmYdXOPHVXXcSztCUDKTiWnlR2pYpurSkOHJgoDP3hkt98cfw=="
+
+[[package]]
 name = "libisl"
 version = "0.26-1"
 system = "archlinux"
@@ -138,12 +130,12 @@ sha256 = "b6f495748d9c877c15e47e9691e09d86139cd234e1990a97c531d8d8c9f993b3"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZCq2IV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkzKAQCFNdVbwWwjQ8+Ba+iGYklKxxlcAJoUXYPsy1OChLCUpwD+KsxGh2JyiO1aP5WOmsDBRXhqNB07z3dNBVwNL6GwNww="
 
 [[package]]
-name = "libldap"
-version = "2.6.6-2"
+name = "libksba"
+version = "1.6.5-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libldap/libldap-2.6.6-2-x86_64.pkg.tar.zst"
-sha256 = "bca05e41dafd853677e7351228bdfaf2ae650ac77b358b71784fbdc728436cf4"
-signature = "iQIzBAABCAAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmUhyZQACgkQeGxj8zDXy5K42xAApYm1IBHqCrUiqy7fSRVlt9HGKyU2C0lFIiLMbClaq9fUawA3W1/u1Sq+znmHMrquTLSi25rl5Ho4bjYJzBh5DBK3YTaGXgP+mJJE2s5oIyWPQTLoeFZnVbOq84hdUxXs7aRQBbwE7+2KA9Wn2qxShGjE6XHfyfdB39KNEXLIf/WuGrOF6BBNVd4SO+bSEbxS2NxG7mRtvxY3bRmB1TiTveU+RBDL11z/gDj7ZGL6waoLGlWF027I+ItSBwK7VIKmb9FafTfRKYsKF71XKKInTZqLXR3mkDX5cRNzUx716ii+gdmwKgVWocFrtTmHfJhl0KL3FK2dK+FuO5nAox7EhBcDVAqxfIrrH9FQXXIGtB+7gCSb6excjDh9DL5CCJ2vLTM1i8bM6zV1mSXhp7pzVwKY6WDNTjg9/gvMKDjRfDGgKYGJsiB8vK0SxtSCmnCF5B1w3mZxoEjyVwWJ5CL8rlnTM97+QUqBxp57he3IXZeWYpW/T5eRP6mR1KxB9NpBM5t6Nk9S8cL/+kmT+wVeaZR1ulPVYdfVSC/Y6J1HtZJcVgssWvOtTr8Zw9XsosrKz3OlWRVfUk7I6D69qHVxciN93OBO+LIQGQqd3Of/2FOvavTu7j4lHXAJgJc2xRNeX8uvST8XbTtQlHrbNqWL+eWxWd0X5W8CAMjXqLmyDOM="
+url = "https://archive.archlinux.org/packages/l/libksba/libksba-1.6.5-1-x86_64.pkg.tar.zst"
+sha256 = "d0da35e18d4bf003b5f9c7d787d1abcf5095b2a6694db3cc51986c2613369b9c"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmVYlJQACgkQdx32Yn7faB/V9ggAqYW08cCbdG13Cm4EP+eV8ZEzeQW/0w6ZN7hAFgNHUrPGdBt48dYaYX2G/CVwZoq/d1ieMW5vaiK9frIKrKfwoFl5yoQjgA9Brt8Xn6LfG5ltpaxm6E/NftN6r2m+tB1lZb3YEeQfC3E+MKDPHwoIGNLJby0BLsbIf6m80efURWnvZJCylg1NQBNk1Yn4cjN9DQ9Emf161/I8LX+jEU7WIkR4JBRxqE0smKrWFg0M0Rn185A3koU/HI0/izatYXjg/8epvPz1ALNOxgEPXVnt1hZR6N+93zdvJh9Ev9OzSRj18Uja79GlTWA0CsBV7qeu5o+l1veNvuBhfrzllW7/tw=="
 
 [[package]]
 name = "libmpc"
@@ -154,44 +146,20 @@ sha256 = "a83324a476cae86887aa3e3811b2e72c31471a81be0254e379c244e2df531c1b"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmOfE/EACgkQek52CV2KUuRNEwf6AkQRJ6MKo3+8qZ5DoL1AUfEbRy332+0DbmhqVAZAVR6SDYwr8yTYc5L9zWtRYA++Nh0zah4P6o3XXJISOfLLpQHGPI1jZ/1IGTJlCt0yo+KU891YfQQO95TCAa77oT9Njkxr6imF0vP5kR3PA5sEvqD0iCu69s0TQu2uzsVqigNmbWU3LVv47BrF1T+C31Oa6cRWmjDUtn2ls/jYn+BPvuCO9TyH/3d2lQ1CCM+H1cCDcxzBSmaYSVQUbM6x8YAdFKDZKEbwuiCGTwKIV5ZRar4UiiBdeuJzF0vSy51VdcZpvf30HU8VuJ2Q+mv5OfyHjt/HBCkEyn1b+XufIqb0Xg=="
 
 [[package]]
-name = "libnghttp2"
-version = "1.57.0-1"
+name = "libp11-kit"
+version = "0.25.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libnghttp2/libnghttp2-1.57.0-1-x86_64.pkg.tar.zst"
-sha256 = "50b7ef8e00d0f2bd4f9d1ebd376be9c3c294f805b0933cad12d3357ff0b9d3a3"
-signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZSVmqwAKCRBtQr3RFuAGjwTbAP47eUBW3hVJuM0oe2VC6Zu+rcJmQfnjW1t4DIvrB/utMgEA0SIPVT0eGM1Rtc9WlzT4ceYLCG0dnsdC1Kwm41+G2w4="
+url = "https://archive.archlinux.org/packages/l/libp11-kit/libp11-kit-0.25.3-1-x86_64.pkg.tar.zst"
+sha256 = "f63151e2d11cf36d717bdd43cc895ee07b4dbb5cb85532a019f1342a29f24960"
+signature = "iIsEABYKADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZVTTCRUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8cebQEAgaxhCgg6acCfxxwhEa7IwQqLFlLHIeLqZYJLqiybyV8BAIDHQQr+4IBxLMjRg71AuyYJcAIWtIwk+jsZczFr2WQC"
 
 [[package]]
-name = "libsysprof-capture"
-version = "45.0-1"
+name = "libxml2"
+version = "2.12.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libsysprof-capture/libsysprof-capture-45.0-1-x86_64.pkg.tar.zst"
-sha256 = "7f33a777c180a23e5de12358ee088833b5321d1251e574ee58db13ed2af7bb4e"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZRn7vBUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8ehMQD/a0fCayinEBKKYLNLZuWG24AyUd5/dSA0pIn68m5iQloBAOEXXlWSKk3j5HQwaeK7diEC4cJSBaGmW0//WNdYPzYN"
-
-[[package]]
-name = "libtirpc"
-version = "1.3.4-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libtirpc/libtirpc-1.3.4-1-x86_64.pkg.tar.zst"
-sha256 = "f454dd95f9bcd0d4e2381f7043ef8bb78bad912877a1b8fdddac9fb136a04311"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmUhfywACgkQlGV6sg8qCSu86AgAl2Mzr2Np3923QhPPScZPnmvXmHbxyZPAKdHDp4aRD666jEn9f2MfaeqQMm8l2bZK/aYGuFrQJ0YU9gCN8h5Gmo5XtkKV42mgs6c6KRekRhLdG5fQDOImuKVKI7Ww7VlbE5fasPsB/PmrcY08gGkR9FGfpCSJvKMyPGcsfboIKPvb79B4iqU5h91O2baB/JyGw48Cwp7IrTsqe0/5t3D6GfPf7NpS400837jEZPwZr8blNNC6MFT2tx/C/vIrWRrLChgnWcJDIbNHmb6XkT58D+2UX9wG7g4FqIyNF9wUIJt4BJhQawr6THJlkDzkZNeqO6/oxKwjm7BwM9qqUH2esw=="
-
-[[package]]
-name = "libutempter"
-version = "1.2.1-4"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libutempter/libutempter-1.2.1-4-x86_64.pkg.tar.zst"
-sha256 = "3bbf7ee183ea47422ffe867122f07118d6a1b6534b2e5886f13406c9f670bfd5"
-signature = "iHQEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZSDCxgAKCRDylr3lA2jGzkHdAP9tBDJ9TbCCQbOaqPgDMJio3KxG6qpE4JDdj/0LQDkCEgD3cmJU7T52BEsou97sSp+2h9zWNADjdR8UTEFi1leiDg=="
-
-[[package]]
-name = "licenses"
-version = "20231011-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/licenses/licenses-20231011-1-any.pkg.tar.zst"
-sha256 = "27333bde42cdf524dafb9fa10e8ce1c4a37643cbdcc683884d7c69a81358e249"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZSZY/wAKCRCbeih9mi7GCBwPAPwNx91hoAyomW/bi+wZRhvPwqK3sZDFE+VgKcUQoDNgHwEAhzJNArAdLNlily6KjkrgDgXE8uzJTzC+4gY5EtMQ9gE="
+url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.12.1-1-x86_64.pkg.tar.zst"
+sha256 = "440b0932dec86e58ec524b4b1b8490586fd6f928723ac1f2fb73af61b9f66b97"
+signature = "iHUEABYKAB0WIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZV+bJAAKCRA7lKgOUKR3xxSJAPwMkOSZjKlaGc9URhKSyxJhOFiOwLUCAjzi5zN2NSrm2gEAiV8bmWjLs7aAEm4A4ysDoew42T+8g1ark+1ZH1KhXQs="
 
 [[package]]
 name = "llvm-libs"
@@ -218,49 +186,65 @@ sha256 = "f585ddabdfde5a29b88193827ccc597f74feb878723da9ce813d882c956e19b0"
 signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmRRZ5gXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K1VGhAAwoRqJgoycDFQInlZtrXoreYRhFdIJhknGCtsAWgGvYY5CDrEXQwUR3zHpYahzka6CbAv8aZdL67CIZELQ55f22xFyAIyeBLGl21QsI/A3Isom9+IVrOOsIc1+Z5LNp1LTZkAPiK1j06NWkaRpzL6NaFeUf2ziq8q/3lDfXaalyTmy6hV29ZMp8Gsa0gcsCtremCNJXVRwOB5/Hs9a0YJwOheNHuqEc6Md08N5rrE+HkTxMJB62FZn9ta1UqpejnvLBr5Q5yNKFsDuc67ZY6AIBlS/x2iyPDidvzbULj+5fs+4wllkK0svUCUHcKjBjFazCMX+bzS80EymuyzB4dkPxAxJ2/RVsXvFkhquKzAcFEOyZ/CiJiaRfeTZHzcmA1u6tjcl2wopc886wJgX08YqJrlXNQ5jbgo3jkHCUWlVYau7IF9pb+cekgPX6ut+n4ZzZUbaP0yahmzZq5gPsdHf0uKQoVjgxxGhWz6mrllpy/EeKVks0bj/fiHE9Czn0naLoaO5Y5ww25lg3DrAW3GfgTepRW0aXEoecDM9izGkw8D+BqUyV79z7qE5El/ndymyL8dOxzIFIMNFJePzg2E/Av7inXMV3H6gFs6Tw/LmbzQVi/RRO6k4Bill3Md9udh+0waEa70Gs9n2dxNN4C8R1ubeA2yDzQim0ua8caOmT0="
 
 [[package]]
-name = "pacman-mirrorlist"
-version = "20231001-1"
+name = "p11-kit"
+version = "0.25.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/pacman-mirrorlist/pacman-mirrorlist-20231001-1-any.pkg.tar.zst"
-sha256 = "a7f7370ee4adae04d7682eea459c67b42a3479f84dac6f76cf4ad920429fc205"
-signature = "iQIzBAABCgAdFiEEz6avFeXHQUn8HYwIbRZVwUzhwT4FAmUZcykACgkQbRZVwUzhwT7gPhAAxlGXrRtlfb/acEdG7DV80tu2n62uBqtTjtAYKFYmK+NsE4CqqFJjfWP7pfBWGin3OK6hex0BvLIx0tLmBYqJKxaiF7c6WdTusawRGFLQOiNoNpb4v7HnFn1m/mR4zmgiOgL9rJzQjE9tK9vymSPyNOxrJ7xD7NIyr3fOYoGEZwbvZVpl7vYpm9V1TnEhOBDYDvGOfNFYrEKV17UdSdTU99xme6G4tVwxgYAEfI2Ws+YJDHC9/VbW8eVTEd3Xhd2ae+uFjy3FgMHO0ZhVpO4qPNz0ZOlMHYXeoiUk7l4Dp14ITJjaW4IdOxj6fw8fyJ+uv7r2dSS/qQZNgOIbwLYKNROKDb9erxLKeK8ticCETuZdDhrk0MNcbaQTS81jiLyBmuwJP9Twv2WDH2Tbq1t+HFQjOAxmTiOrlVsUWMUIw0xbGBL8Iyr51rfLlpAvim3RyGdfPOc6H2JYi+LacvVbGB/rRb/oY3bdj8NunwBLOqimilKpwSIZIzmppgiule4Gh/JtHJxYXHVTJhNLAS08XEBcoqjTX4XURrwMMVA3ebhiZ1GU2KNPrWhGQCGo/nQXw70yRxz3oDFrlf+teyWZ9uptFiB4GWKTlQPi7kNebSa4ipHd10YJz7VKgKBgGjaYdNLyvzJWel1eOfMXJIF5eZ6jMTsrak5MlaHWIjUdztk="
+url = "https://archive.archlinux.org/packages/p/p11-kit/p11-kit-0.25.3-1-x86_64.pkg.tar.zst"
+sha256 = "032b4c5a11ae3ebf75e451f18a77a4ce2293c17ec0936c7ced90c5f2ae669e4e"
+signature = "iIsEABYKADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZVTTCRUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8eOeQEA+UMdpgULptNY8ipa/5WtCvBqEIoTAl9ukqArZ1PV5s4A/RPMgQCqemHqKPYhBM0rZrhUWUzig7MBN9TL7bIG6M4C"
 
 [[package]]
-name = "pinentry"
-version = "1.2.1-3"
+name = "readline"
+version = "8.2.007-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/pinentry/pinentry-1.2.1-3-x86_64.pkg.tar.zst"
-sha256 = "5793f2cc243552f2cb43adf37c76a5f4480d94d1cf87cc46f29e0cec1b647017"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmUZVmUACgkQek52CV2KUuQdJQf/SPth1moSSyuOV2LgZh3GMS9AyYtnUQDKQz+9t7YQq+vAOS8PaqDmGzFhgBA5zeYonMXfDRxu/EhAj1OwvSwddMg1NQg5qh9gI+ca7OLRTjJdJCZKLxOaMLo1UAwQD8597esTVZh+e9NoEQE8clvn15rjCBG4K1rvUhQy/qpsMY/FPG95yMrh5JPXNAA+BtxbEManxDNRTNhDwijUPVLZxbUe4ywKdywdp+2nIltHVdGaeaMYCKse0JAcCPuk1GXr6FA5EtoBAySolQpf4T9G0MpKI+4Zagcfhi+uqInMOvbp77lGsLA4Xljb/KWwnDrFJA8OTkbonmnFUZFyv5aTpA=="
+url = "https://archive.archlinux.org/packages/r/readline/readline-8.2.007-1-x86_64.pkg.tar.zst"
+sha256 = "62b2a573cfdd83078609b338cd734703d8b07d7cda8502c2698ad2c269c29444"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmVeHvIACgkQdx32Yn7faB95pAf+N7yFoSdy8AqCbSYDMYO4iwXMxS/q0NP7HZgUqjCf4mMbTCgKQD7Qk6zQnDGhREWcEoM13brgn9LDB1/AvDkHPfPCfKWU3qjE5LCUxS7lLS22wjyxNLZAasyGtMbkwRWxyxB43i1Gks0idR4LrT8AkcTjhAvIOttzBv8t5QDIcu1N+w+U47fT6mxa4yBA9eIP6kuryaItl+xFPMispgWTyOEwf/2koBOX9KLAaDaAdt6PAI+TWgwvmZ98X7PO8NtzbK9KI+m+KMiJTANkmjkBAgRSk2bsEdGGic6zARtywMvOBpEGF6Qr/1vU4U9yjt22wHSTmu4JQ6OJ99lcylENnA=="
 
 [[package]]
 name = "rust"
-version = "1:1.73.0-1"
+version = "1:1.74.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.73.0-1-x86_64.pkg.tar.zst"
-sha256 = "b8b675552bd861f6c73ed171a4859e1977582c06ce6444932ac2b9013c1a8187"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZR8fhxUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8fntAEA563gbujw/HRneQo9jiwcwAtOzLzEkgrT+3UV54rzL2wA/3swtMKK6heyije/sypO7X+I1BMJvyGuUp2pAXXOlLoE"
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.74.0-1-x86_64.pkg.tar.zst"
+sha256 = "577404c8ce99d59e6dbcc9be4139afc33f560f584de9db0b35f862ab4d176651"
+signature = "iHUEABYKAB0WIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZVYx9QAKCRA7lKgOUKR3xzGOAQDEsuxiq1TtncZc6/z9ItFF808uw5S7FCMRz7Shsn0j+QEAqIcOg4ui+6uf/OnCw3sz+xnVN2+NoJTCpIs8uds4RgA="
 
 [[package]]
 name = "rust-musl"
-version = "1:1.73.0-1"
+version = "1:1.74.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.73.0-1-x86_64.pkg.tar.zst"
-sha256 = "0ee472262c25fe033e14c85133cb247460e4daa2291c4e286c7a76eba74849ee"
-signature = "iIsEABYIADMWIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZR8fhxUcaGVmdGlnQGFyY2hsaW51eC5vcmcACgkQO5SoDlCkd8focgD8DhltUwUen0iUO7wne3ejHGrhI4OXlHL8cHIkb+mrpq8A/2zd0Z5xCVeIimRDiJNpb69QvdsVY7iAUXTNJLsYabQO"
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.74.0-1-x86_64.pkg.tar.zst"
+sha256 = "72455258731d94e88fb09253c409f9d025501fa10c8ffd670f7c8c82874cb22b"
+signature = "iHUEABYKAB0WIQQGaHodnU+rCLUP2Ss7lKgOUKR3xwUCZVYx+wAKCRA7lKgOUKR3x7A3AP0fGBAqHuirWSnk34HlOB03/YMJGxXtEtooqiBDZXvOYwD/WUeYKULRuoT8ZIKW0xNf/ywKZg21WjQKnU3lZwcbRw0="
 
 [[package]]
 name = "sqlite"
-version = "3.43.2-1"
+version = "3.44.2-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.43.2-1-x86_64.pkg.tar.zst"
-sha256 = "e8436fde110d3c79b46ea0e601740d57003c17fe17f804ea52679e6811e0b5c1"
-signature = "iQEzBAABCAAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmUlqskACgkQlGV6sg8qCSsYEgf/UShuN718zzGtVeNYwVQjCYHJHtdkqs8AVtz2EbCCPElLVdShbReqHPC5JYEUAofqb3FTFzatgGeloHzv+3k6Hu5s2eE0UXBJoP9aMUwzcTuIvEgZeDucwVjq5UFvyNyYfgu1VcdNnKIJD7uUJfIwPcoPaS0dkR+EInorueCDd3u4wpHovZw68ofWiEO/LLuGWwNUNHlVPtzk8xo+AD4AK4Gn2LprJXXC2wKvverQ4c+1EsshRi6/yyvLWi/GBcePRWgoSFFQqInu2w2NV9Rjtv8q80PqOv1VGfHaFERFEUSkil7TkwMV2Ul+nDZu1zeq9SM3ZeiPBtOcgO2H3q7Y6A=="
+url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.44.2-2-x86_64.pkg.tar.zst"
+sha256 = "7c7ff180693b24d5e4f170621e9f13126b23d59440a315588b3cc444bc8fc693"
+signature = "iQEzBAABCAAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmVjT00ACgkQlGV6sg8qCSvBfAgAs8FCCD5cezTsNNmYYmBXDN4gE1oe4GIUA2uR6NgLhSDBxo3swPIGNBxapRBdOxBQRT+B/gsHV255RDxtwdtaQqzv8vbiRPzuxtyihJPcAsXDTK4yB+Z0YTF2pZtN1WhRbiYneMXRmcajNMAt5TP4zwMOdub9Y4SOWE/Zcxzmy9feWwruVdVIlQIeEibfH/nKmTheXGSEnkva6ISVIZyCK65e4yg6RutBieYWVQlNdeJBPI7t9x43RYRFHgCJGi/XIsxxQEg9MCKjnwtZ2d9nhpTb7jCVVucYAwtb2/3GlWRsiknuHEJbrgRPgcnsyX7NfIOpAfx7oRRWNzEF5+47tg=="
 
 [[package]]
-name = "tar"
-version = "1.35-2"
+name = "systemd"
+version = "254.6-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/t/tar/tar-1.35-2-x86_64.pkg.tar.zst"
-sha256 = "76d2aa4c56ee9a70f71246bde8b7fd3e0405c524c9a572d7e64b6431f72de2b6"
-signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCZRgR6AAKCRDluymEcK1OQbhqAP9VbzdP2UkqunyW+Ucs447d1YfI3EeMze+JCXtlu9VrHgEA/ZJ+TDrBOozRe6TB15eLDWlMqR9Zb4MxPi++WdZi4gY="
+url = "https://archive.archlinux.org/packages/s/systemd/systemd-254.6-2-x86_64.pkg.tar.zst"
+sha256 = "56f3629ea1656b0d55cc40e7d7bcdf4aa4b3e2526d0b2e293eaa1beadee2f229"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZVHgzQAKCRBtQr3RFuAGj40cAPwKR45z/xGeMAQoJn06nrJv0WUZQOQ8CWEJF+v2CubNmAEA0UEpQMn9YGv31GCgX6eQQGsnNCOxRwKOejQkpHZvcQg="
+
+[[package]]
+name = "systemd-libs"
+version = "254.6-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-254.6-2-x86_64.pkg.tar.zst"
+sha256 = "9d15863be6832f6c3e65a0deb8e743a3d663c1e3a93662932a2e6577ea80ca18"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZVHgzQAKCRBtQr3RFuAGj1R5AP4sPEup+x5rqk/4moDqm7tn7FynpkuWyam+Pva65PneIgD9HGng39HqGgmH+TmfyL00rf4XWP5o89mrg3/KDXv0bQc="
+
+[[package]]
+name = "systemd-sysvcompat"
+version = "254.6-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-254.6-2-x86_64.pkg.tar.zst"
+sha256 = "278b0662ff0a68dc0cc54982eeeecf63b096665bfa1ea8a7dd88cc2779111698"
+signature = "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZVHgzQAKCRBtQr3RFuAGj+4LAP94JIlMH8O1emNUfoBE21Ko78IVVPYzNAJYAsPcdv+GhAD/d3rx/r0rLqNC2rIH+UkRJYs08EWh/kh0xBobkYPYlAs="

--- a/src/container.rs
+++ b/src/container.rs
@@ -110,6 +110,7 @@ pub struct Exec<'a> {
     pub capture_stdout: bool,
     pub cwd: Option<&'a str>,
     pub user: Option<&'a str>,
+    pub env: &'a [String],
 }
 
 #[derive(Debug)]
@@ -156,12 +157,19 @@ impl Container {
     {
         let args = args.into_iter().collect::<Vec<_>>();
         let mut a = vec!["container".to_string(), "exec".to_string()];
+
         if let Some(cwd) = options.cwd {
             a.extend(["-w".to_string(), cwd.to_string()]);
         }
+
         if let Some(user) = options.user {
             a.extend(["-u".to_string(), user.to_string()]);
         }
+
+        for env in options.env {
+            a.extend(["-e".to_string(), env.to_string()]);
+        }
+
         a.extend(["--".to_string(), self.id.to_string()]);
         a.extend(args.iter().map(|x| x.as_ref().to_string()));
         let buf = podman(&a, options.capture_stdout)

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -31,6 +31,8 @@ pub struct PackageLock {
     pub version: String,
     pub system: String,
     pub url: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub provides: Vec<String>,
     pub sha256: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
@@ -63,6 +65,7 @@ mod tests {
                     version: "20230704-1".to_string(),
                     system: "archlinux".to_string(),
                     url: "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20230704-1-any.pkg.tar.zst".to_string(),
+                    provides: vec![],
                     sha256: "6a3d2acaa396c4bd72fe3f61a3256d881e3fc2cf326113cf331f168e36dd9a3c".to_string(),
                     signature: Some(
 "iHUEABYIAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZKPPXgAKCRBtQr3RFuAGj9oXAP94RQ1sKD53/RxVYlVEEOjKHvOmrWvDkt1veMYygnlnIgD+MLg/TT6d71kE8F08+JH+EcnG7wQow5Xr/qBo1VPLdgQ=".to_string()),
@@ -73,6 +76,7 @@ mod tests {
                     version: "2.40-6".to_string(),
                     system: "archlinux".to_string(),
                     url: "https://archive.archlinux.org/packages/b/binutils/binutils-2.40-6-x86_64.pkg.tar.zst".to_string(),
+                    provides: vec![],
                     sha256: "b65fd16001578e10b602e577a8031cbfffc1164caf47ed9ba00c60d804519430".to_string(),
                     signature: Some(
 "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCge2AQD/LGBeHRaeO8xh4E/bAYfqd1O/OFqk2DrQBJ73cdKl2gD9EC8p4U/cXQK8V774m6LSS50usH5pxcQWEq/H0SF+FgM=".to_string()),
@@ -126,6 +130,7 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N
                     version: "2.40-2".to_string(),
                     system: "debian".to_string(),
                     url: "https://snapshot.debian.org/archive/debian/20230115T211934Z/pool/main/b/binutils/binutils_2.40-2_amd64.deb".to_string(),
+                    provides: vec![],
                     sha256: "83c3e20b53e1fbd84d764c3ba27d26a0376e361ae5d7fb37120196934dd87424".to_string(),
                     signature: None,
                     installed: false,
@@ -135,6 +140,7 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N
                     version: "2.40-2".to_string(),
                     system: "debian".to_string(),
                     url: "https://snapshot.debian.org/archive/debian/20230115T211934Z/pool/main/b/binutils/binutils-common_2.40-2_amd64.deb".to_string(),
+                    provides: vec![],
                     sha256: "ab314134f43a0891a48f69a9bc33d825da748fa5e0ba2bebb7a5c491b026f1a0".to_string(),
                     signature: None,
                     installed: false,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,5 @@
 use crate::errors::*;
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -23,7 +24,7 @@ pub struct ContainerManifest {
 pub struct PackagesManifest {
     pub system: String,
     #[serde(default)]
-    pub dependencies: Vec<String>,
+    pub dependencies: IndexSet<String>,
 }
 
 #[cfg(test)]

--- a/src/resolver/archlinux.rs
+++ b/src/resolver/archlinux.rs
@@ -174,11 +174,20 @@ pub async fn resolve_dependencies(
 
         let pkg = dbs.get_package(name)?;
 
+        // record provides if it mentions a dependency
+        let mut provides = Vec::new();
+        for value in pkg.values.get("%PROVIDES%").into_iter().flatten() {
+            if manifest.dependencies.contains(value) {
+                provides.push(value.to_string());
+            }
+        }
+
         dependencies.push(PackageLock {
             name: name.to_string(),
             version: version.to_string(),
             system: "archlinux".to_string(),
             url: pkg.archive_url()?,
+            provides,
             sha256: pkg.sha256()?.to_string(),
             signature: Some(pkg.signature()?.to_string()),
             installed: false,


### PR DESCRIPTION
Having this information around allows detecting if repro-env.toml and repro-env.lock are out of sync at some point in the future.

Also allows passing environment variables without having to invoke `sh -c 'FOO=bar ...'`