### PR TITLE
Rename `make build2` to `make repro-env`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbl"
@@ -1198,9 +1198,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -1466,9 +1466,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1479,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1611,9 +1611,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2433,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2459,9 +2459,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,21 @@
+# Compile using the host Rust, then run `make repro-env` inside
+# the repro-env.lock environment
 build:
-	cargo run --release -- build -- make build2
+	cargo run --release -- build -- make repro-env
 	sha256sum target/x86_64-unknown-linux-musl/release/repro-env
 
-build2:
+# Used by the previous step inside the repro-env.lock system
+repro-env:
 	RUSTFLAGS="-C strip=symbols" \
 	cargo build --target x86_64-unknown-linux-musl --release
+
+# Keep `make build2` compatibility around for a while
+# Use `make repro-env` in the future
+build2: repro-env
 
 docs: docs/repro-env.1
 
 docs/%: docs/%.scd
 	scdoc < $^ > $@
 
-.PHONY: build build2 docs
+.PHONY: build repro-env build2 docs

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,29 +1,21 @@
 [container]
-image = "docker.io/library/archlinux@sha256:9d95c7c95276ea44e5e87f4974672a91f46e38e91d60f5c342f94274f477aa40"
-
-[[package]]
-name = "acl"
-version = "2.3.2-2"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/acl/acl-2.3.2-2-x86_64.pkg.tar.zst"
-sha256 = "9bf86d3e2d7792e3e721aa293d772bbc4d99e3fb885467a3e16189dbea819432"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCadv96QAKCRBtQr3RFuAGj8xBAQD88RW94TN2uCzfiPG7rDkGLlkYO6Q5ZaT5nVFt9C9jxgD9GXsDbuzDOHm23AtHMCExpsIK32NkkNSwIvJRjTaFeQg="
+image = "docker.io/library/archlinux@sha256:52c1b90e0bdffda8bac47c8cf87c5a1883b184fe3513b395f7983559766f9625"
 
 [[package]]
 name = "archlinux-keyring"
-version = "20260409-1"
+version = "20260420-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20260409-1-any.pkg.tar.zst"
-sha256 = "0002f6fbdce314f5423642b0e34c42214483fd8246f36b7f0b02b148f341ecf6"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCadggiQAKCRBtQr3RFuAGj6MWAP4tMaRsaos98mKgdZpFy2xdGxIds6GBja/sTADjKrxKDwEA7VP0VuQBtft0GjNqZ5TGB8mwCW2SmqsX/ZP0H05LAQQ="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20260420-1-any.pkg.tar.zst"
+sha256 = "6ae55a078b8f5d7f3c9c661ccd052bd114b52fa03b8c7c91a453ff2aaaa18716"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaeX1pwAKCRBtQr3RFuAGj2R9AQD0CsHYxC1hGmiTBk2eutMxKpy1mDnhpjgzMS7KP4F4lwD+I/vBe67cpLjCgMrd3sFPKq9XWQvmGPwsCtMAsdefGwA="
 
 [[package]]
-name = "attr"
-version = "2.5.2-2"
+name = "ca-certificates-mozilla"
+version = "3.123.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/attr/attr-2.5.2-2-x86_64.pkg.tar.zst"
-sha256 = "a261a43fb2dea7dc0ac1d389bee113781ce71fc5d176a98504494d034557e5b3"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCadv9/gAKCRBtQr3RFuAGj4AcAQCExs8YC/TpR4AeezcGbk4AD4S+Fvo+sTbpxBTo/e5VJgEApc4+PV3Axi6qdCevu0m/LIlm6aZmC/RZVjMjPx3+Dww="
+url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.123.1-1-x86_64.pkg.tar.zst"
+sha256 = "c04f524c8ab7789fe5df12de4397a292644962d889392765b8d15744846fc6d9"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaequKAAKCRC4rAhgDxCM3xuoAQDl5r6eVTcC1UU2wfVQ1z6bJZNtZzfSeU1asNVVrKY39wEA6rN/PCOKQiOuapMunTJFHeZEgdyGM7kHKd3pIodXmgs="
 
 [[package]]
 name = "compiler-rt"
@@ -34,12 +26,12 @@ sha256 = "f08663351c250eb91c98b58dfc7c7c75fd224ec4e7501287a4922d1d9f7d71e4"
 signature = "iHUEABYKAB0WIQTS6V/sAVzx+RGqqww9TFAIu1yNKQUCadUh/AAKCRA9TFAIu1yNKdWiAQDTWqFyaqVRzQ3YAT6bbNsC8thEIL2sPg1I8zXwr7rPAwD/foGbzMtZwS8pskBsravvPinoLXxz4kOZhNytG4K8zAI="
 
 [[package]]
-name = "file"
-version = "5.47-3"
+name = "coreutils"
+version = "9.11-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/f/file/file-5.47-3-x86_64.pkg.tar.zst"
-sha256 = "e48137167a2d8cdcbb8a273b2b3785e9bc71e7653d283e286a6242e32452c740"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaeCGZAAKCRBtQr3RFuAGj0SZAQDQdfkud9HSGI5Boib4E/4IDilZg7lm0bIu1xK3rl5MgAEAp0Bq5ip+fc73eOKCGhY5Q2tS/WTE7A4FqggB17cqRww="
+url = "https://archive.archlinux.org/packages/c/coreutils/coreutils-9.11-1-x86_64.pkg.tar.zst"
+sha256 = "1358e5c8d4466abd2fd8b3beae066d4fef93180355ef46a68c1cbdc9981dca90"
+signature = "iQEzBAABCgAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmnmP9UACgkQdx32Yn7faB8AaggAlNxM26lg5MAZx4J1uhsIkqkq2IbzaGXdja7hVDOA0UCODZldySAP33c7fpMN16jaUnW9750/vpckyz6WFoPl+3ASLSczKIoSJs+PvD9Mb6vboBXrBTmAw5GgUqpJY9mqFyBQHTFWmbI+auHXugnp+qC8U2SKS3BB0VVjGtfu3eWF25oMeg1XjTHIyM/y8yrFbvv5J09TN+yh6Dc6erzukopMKYvh/g1zfEzRHUFHewQAw8FLaJsZYC3I1X4Ymyg42YC8JZhm3ZAwkSqHbWvucqZrvxoHGMBOYvKq0wEsyvAUhsEsI9BNi4P0dM3AhQVcKVw9N/7QAOUHrTNlfMGyJw=="
 
 [[package]]
 name = "gc"
@@ -58,6 +50,14 @@ sha256 = "2eeb789bf4e359ae6cb26060d72ab59cfe1cb24d27aa3b5db6360f6ca1fb4667"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaYoLM18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCihaAP9aQvYG2QmpyypXlbpn12n5Elo/qXoowTnjWcxSKTPCLwEAwuYphXaQFaI0Qs49kdSfPmNaGQY++fQ8+0+qoZNDyA8="
 
 [[package]]
+name = "glibc"
+version = "2.43+r22+g8362e8ce10b2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/glibc/glibc-2.43+r22+g8362e8ce10b2-1-x86_64.pkg.tar.zst"
+sha256 = "f2a9dd4f5e6dc96209f63f1ab3c118d4f862907bbff32c83fa1c6e3a49ab860b"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaedc7V8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCorbAQDfGyH7cV1YWJrb+K7sdWsnLnvMWD29g4gmRmIjL5ZAngEAqfmvGwtK4T1d2EnTbu5fj8LJYLJh8+30QO5aaSDKIwI="
+
+[[package]]
 name = "guile"
 version = "3.0.11-1"
 system = "archlinux"
@@ -66,68 +66,12 @@ sha256 = "dbc4c775e0474a5ac8784aab95a77f6fd23ebc930abea34c7a5e0f83dd00873d"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaS4I218UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCjiKAQCqa5N4msMDL6n3cQiVw8Cs1Jlda8Gtsf2O19E55qxHWQEA/Rl+8nsXY1xsUedEIo1DwVhhaLvCEafsKjFk4d4mMwU="
 
 [[package]]
-name = "iproute2"
-version = "7.0.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/i/iproute2/iproute2-7.0.0-1-x86_64.pkg.tar.zst"
-sha256 = "7f245ac61818ce4ba7e3650468d07b9c047dcb8f1ccbf37ff5e6f892523d16aa"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCad3KXwAKCRBtQr3RFuAGj7IQAP4n2lqgyLOFVz2XaqaZodRi5VnL6G2lHqeAtsHBklikBwEAzG1U4/MhCq1NQAmxX6/e0XIAbrFlr8KQhfHxtaz3kQQ="
-
-[[package]]
-name = "iptables"
-version = "1:1.8.13-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/i/iptables/iptables-1:1.8.13-1-x86_64.pkg.tar.zst"
-sha256 = "c827ed573b29dd488317da6b61be22c5d12154378b6bceda35ced834e8bbbc94"
-signature = "iQIzBAABCgAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmnXc8kACgkQeGxj8zDXy5KLghAAh5Nvv3UMk5QIwQzy1fEgrpsDg0gY21k34Fc9F3CWig+pg1zmA7uDUgoakGchQBU5Peo/WwxQ9DgCLk5tASQLlFz2wHsU4nEy1LnNDjrw2yWVbsEu08HqVFmpRtrQrx0Rt+XwBbjT2p8XzRuMSKK+Oaoyl7HLQh90b7ZXljtHttb5pjtbDDoe4jf10AA5wH+kXv2I9bqc4T8ePmtGb6kRGYP8QAvXV8s0gw1P9muUGP1XKpb+qAcN8rL1VBWHb+/APmKYiJ76u2NhZLkvR2+L0TOLnyt6MQHRa5IXqTpXoGNlQzYSuRGLP9N3iOOnQ5/uiQlnR2WtklQt7wKkRNqnQlhjXTvqShknxYQETiRBDi+aObR1PhhkP1oDp42LK1DAD2sBKS+DDgzC6HxqT5ZiN/TJvudw6/dYejLr4NMSVwGIIrJutji1lPSV4AeIjb6xPRa99n0MGFkx7PaF1VNTk4up2d8WP+GMA7aKe573JNyLjgBgG5Nlu/nMltdxyO9Z7HJtqxIy7Ci1rnyzsZlHQvxde4vC0VkrKMJ4yh+aYqq0x+tiBOkSkP+yTZbAf3skb25synjHgsTXvIEfnhe2TrdIrpCmjQ8Pg0dLnw+CZ7OiCsoPCS3X2MyegOQP8NQ7tIYfxOgmUEhv9L47wXECe/Dv6h/bieXNJGE9K1AtCD0="
-
-[[package]]
-name = "keyutils"
-version = "1.6.3-4"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/k/keyutils/keyutils-1.6.3-4-x86_64.pkg.tar.zst"
-sha256 = "e3e5d4226bb7d213a6baddb997bf679a2b1106d95b5c2845b79bf8df1c3ef5fe"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCadv/5wAKCRBtQr3RFuAGj9lQAP0Uz/j+0ETOfZHsL6opVmYoaPk/Uekio4QFY8E9moGgWwD9Fm2u1NAsAGE7uQcwJZMueI5mZE8ckIWiu/WrVj7YjwA="
-
-[[package]]
-name = "leancrypto"
-version = "1.7.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/leancrypto/leancrypto-1.7.2-1-x86_64.pkg.tar.zst"
-sha256 = "7faf01950707e893d47192d4c3549e317aaada898babf524ccc5aa08fa402f3b"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmnakP8ACgkQlGV6sg8qCSttMwf+IpjF+mkJ6a7qGCxOl3Fja0jRT9f3MgKwCfJ+6jBYuNqLaXSl35XL+3ro0m4Bg40YgIyNqh3ZrNssqtT/lictiaDw1gdqQGBLKILs9Z2CBblOksF+ORKRjYj41sSUqAo1VrN0Q1IdzZaUy8uJlg+mlioVDXpIxex3DmvL8ymqvhlhjNBYLRQbtPWwmeDQHiDPWQfneN0ukHqTDqlzkOR+x1y3g3VaqECZKp8ULkk+VnGoGE1QbSRgkGA68+ZMw/YSAQOY0NTxdkPMs12XJr7U5j+rlPX8EI+krQkflIrJOSBuLJGXKyudu0HfXDUgTPWJ01ok6OfQDHNeWznjMxD+ow=="
-
-[[package]]
-name = "libarchive"
-version = "3.8.7-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libarchive/libarchive-3.8.7-1-x86_64.pkg.tar.zst"
-sha256 = "904c83f19359eb677ba1d9c4309aa2edcacdb97bc0462edf31f6e3629d4db774"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCadz0kAAKCRBtQr3RFuAGj9LNAQCL8JwxKQ2ZM04Hq8EFsEopvS6nvh/PYNKVLIEYlIaQygEAgtsnxJJ9BejUsycZ2iR5nMwAykYQlbQ4YT6t1n7yuAY="
-
-[[package]]
-name = "libcap-ng"
-version = "0.9.3-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libcap-ng/libcap-ng-0.9.3-1-x86_64.pkg.tar.zst"
-sha256 = "858f3b207f2601f1ed32756bd8a46eaa266376efa6dd9c7ba16350c08908e41b"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCadiYpAAKCRCbeih9mi7GCFg9AQCaoSQIO61DvJSZ7DkqR9yBXRHv24dpNzPdrJ5bE/1kYwEAoQm0Suj183ejd9YP3qUDCCpzX7As8+weCHu2HPX11g0="
-
-[[package]]
 name = "libedit"
 version = "20251016_3.1-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libedit/libedit-20251016_3.1-1-x86_64.pkg.tar.zst"
 sha256 = "62fd156cc247c3feb8a750efdfbf5842d9a7c07327890339d4342095d6c86f51"
 signature = "iQIzBAABCgAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmmnYnMACgkQeGxj8zDXy5IRKw/+M9+I0lNV6GAHsqFT85ZxcO1HhZux3sdo1/PZsT81Tana8kud9jHGjDfS7zOItz6a0pJ7Q/7CL5BKUd7T6TKLjhFeuiZeBfREiiHqXoXnFopZZzEiXGLu0qDjS1Q8jPfs3BydLIa7niUx6uCjDBegULZkJgyEg+zeUc60tzywrb8/Ii6/MKazq7dmMVU6F+ZQH4Nv/jovsnT6RWS0YexKF0qMZzDRaUCZs7pHkllQJCWPa2O3OdUEhTopKxqWn5UeeMmdeIyyqy7cBhGKmQbbK7wxhQkIpK3Q2By7fLldeXOsrqD64xHXL7dupuXqI+6U/uO8KsNhbJRY2JRI2nUsqDwM8qxoR9OTpjJuBbFX6PzpgluB9c0WD/ISO60o/bcd4iXdkfCb66Tk+Oav6dr5tRVj7ifFzrmmV4Av6UMwtajKiebckOc4WXmgAd4Rd8uMAecFS+Mz7ZIKwaJkFRHGa7L57FpLAh0ox58cILYdqXJdUcwT4vTQvKEXO3ZIvcKmQBc8PhD/iSjEln5KcQy/2B3+e2n3gsVbggykMYHhFY6ae1x2b5Knt17NqCLTj/ITbgAdsrBFikkRCUKHMKthz8YcSYL/tUkrSd0AmxVMteSZUO19bqj0ZTwrU2eI2zqPon4j2rhAEEpohfpfvPDoOvronFeObj0S+nF4IGbmzp8="
-
-[[package]]
-name = "libgcrypt"
-version = "1.12.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libgcrypt/libgcrypt-1.12.2-1-x86_64.pkg.tar.zst"
-sha256 = "27429de23607abb32994f589574d6e680ca3ddf0fdebae82b23fddb4f66ec64c"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmnfh1gACgkQlGV6sg8qCSstJAgAsJ7gi41PAHVs3bHRHNsgkqpF1r3jenDWSgLmax5NWJ/ZBM3kdBBurhuf1n19rpRLUUVJ1PKCIPa/zmQWenepdLXk8vSkfd2bkPySPbop7ATHyxStuv4GnrBj1hjSnYJg82kvqh1eBJ2ErQNo5IV6uW59DcL7BOONrdfUSY+FtqWdO43nqL8eeIkACVfN6j1+vgg08+Ovjjz8pfNDDvM0c9389OPrwCGuVEcfgcFArpcatMI9mG3nuDAho1au49zuXuHQNAR0czy/YslJyeNj5AjJI5sJ/Ilb8xR5dU3MeaDrdUvVqJZrAsL72DMRvTq3Fs5PzIHm6n7v5rfphLytLw=="
 
 [[package]]
 name = "libgit2"
@@ -154,20 +98,28 @@ sha256 = "880bdba957ebe5136449c7b61821e92628d7bdd43f370e5a0818d229372d3851"
 signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmnhAlsACgkQek52CV2KUuSBcgf9E61NpAV+F+wHPlOgZOT9yurZAhQwUNd4SRQkNEFrbyMJ1C3Bu9vUayr05Q+MxeQ8/J0W5aACrWSOEAtvYlu9vfmzbn7/S9rHtH9fmvmj46hZemo48cVTq9YTQA1Doe5e9j3DTOWdEsWv7XCMSIXGI2RdIXYB+TH1DLNi7B95EwDySH7SpznjH+SGv9ttVMsmAChRbGR3fIVi6hz6OgSGErFJJmTI5jwt06U6L7Yhl/4ybvYXuh1DGhdFpNhJBGLcYmQhBhv3OGa2dwj051fEjneL2PK80u4nmc+3dP7cOW3pY8jBDpOVfRvnAwiY/NuJMK1YK3iFd3YbYQnuu1D2cQ=="
 
 [[package]]
-name = "libngtcp2"
-version = "1.22.1-1"
+name = "libnetfilter_conntrack"
+version = "1.1.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libngtcp2/libngtcp2-1.22.1-1-x86_64.pkg.tar.zst"
-sha256 = "5f7ad1da70802e9a954e41bba9ad507f472e884ec0c79669ea4eb66f9d35f260"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaeDYCAAKCRBtQr3RFuAGj4ktAPwKbwUYZZhfw9qLLygvOfYcdcC5t6L19RXcSimCT5AzIwEA7e5c846oeqXT4eLKzk7FVOBRUz8+UFFKVSw8Ng1y5gc="
+url = "https://archive.archlinux.org/packages/l/libnetfilter_conntrack/libnetfilter_conntrack-1.1.1-1-x86_64.pkg.tar.zst"
+sha256 = "9315ab4571be5d9764367f2e3d56004a127a7dfe6fbbfb1850c05efb674a8bdb"
+signature = "iHUEABYIAB0WIQSTtRpKFHmOS6hn0ULluymEcK1OQQUCaediCgAKCRDluymEcK1OQVIkAP4lFlbabXD0C8I0Y3OeREsE5p9tkfi4l1IHo0chQy/L/AD/Yh5KfxasEyBf6Xv+7rxib78qaAP8oYXUk2Spguo0wQw="
 
 [[package]]
-name = "libverto"
-version = "0.3.2-6"
+name = "libnghttp2"
+version = "1.69.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libverto/libverto-0.3.2-6-x86_64.pkg.tar.zst"
-sha256 = "d0965b1b256e330e300c2bc3c699afa24f2d800dc476541039d452b606309496"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmnagtEACgkQlGV6sg8qCSucAwgAizGf+E2M5ENxWMC9yS5H9D0e5LUjGQZLdwVsPO9LD6g6uaiBha3Poul4tCSS4uLIXydVi9weJ9CJoBvo0+oOhA3N9QiUdBZzgsBB4lGmUfU5vWZPh66Jc+7AfIWgQ+YNfbiwJcBIvO+cdQAvyUFRTwpU8JhwKffJSSPQTBk00mYTy4rQG8KAzWZfdQ/0HkE2QGc1Qll6g2BukFRzmHSE+qfZWxAGx5unhQU2Tuk6SpOg6mX2KqKPbyfFReyEq+4TnsropGBB86Lpch6Ny+NXmip+s+I7ElLVx5t3d/zQym+X+OYu3Z7dy+4ZeH/voWMCAfA9PuFplCwS1gTp3qNaAQ=="
+url = "https://archive.archlinux.org/packages/l/libnghttp2/libnghttp2-1.69.0-1-x86_64.pkg.tar.zst"
+sha256 = "18846de3571b98cf657098e2f77d9c9b38d6af0c0497cff665f8b80472d0c62a"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaeUW3AAKCRBtQr3RFuAGj5A2AQD7zNtRE+/UlyAZT+JS14O636mCyXsGkVhH1f0BVMoRmwD8CJ6Otbo4TSCkqjUgcViC6ppJ1NgUcK9bXH5QFDLBrAs="
+
+[[package]]
+name = "libxml2"
+version = "2.15.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.15.3-1-x86_64.pkg.tar.zst"
+sha256 = "51807c20a300bf85db48ae7f2f8967bec291439764b29279e3297dff3247ed4f"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaeDifAAKCRC4rAhgDxCM38C2AP9ZRVv6ndgaUgucsVSQgI4VK7ZmqFHNIpZ4wOIj/CGa5AD9GtqKfW8LS9mD7JiFaU0+msY1pqC5PBHPkXHGapUQtgo="
 
 [[package]]
 name = "lld"
@@ -210,25 +162,57 @@ sha256 = "193b040c7174637ebcb7449914017e4b300089884a659d00bce59888744dc184"
 signature = "iQJLBAABCgA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmm/In4XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K11JBAAtrp8Ovvj6VJOhuR/QKfUDDCpWbcvh+wyqSwXIgRGBR3+m5+HcHkaTUGxtodWpCjiEJeM303SGTgPVsSKlUpNzK/emqhRpKX6pETNvFCjGYZGplvBhdh/LNRf/OMzU2Ld16woc4RUYKciV1LDohB1XVMHpG//QkTHcLOJT4G57NJoS9t0JumxPdZUwEbVrYG56wEMIIVABfY2zb2iFCrjkr1N8GlTCnI8HXpsq0E4yMkhIZ/a1dkFEDmWgFX8g+7JaVVbMFGDaJMGBIM/9bI7Ydc9JtXFbC6aRizF86ZfZdlK3xj0/WAFaqDoj1/O3aToaTqYic/qgPeOqo/nBOyyMxPU9dpz3RBOD9poSiLhjvhERyMSGwuGeAt8D2EGsrUjhJvydF84WfF0ZhlIZIWh1pW+Rf/CPzMeeM3eipLv58HTj5v70JSJuinTM0oIHWoIhsyZPz39dW0UJ+Qqi455f8h8Nj3a/UZfwElNqwLFkV4Qjt9qSRy8twaBNlQuh04PpRhSktRiXNKqc4Ldvcuo/9rhxdByORyfaelYL7OvyX5DyZqmlr1MmtREu4mHU2wN0znRfGinGdVNcqFtFScaABM2tnG8ZE1fOngHg6+P7cFzYYNN8PRaNUHGmSEmbHOoC3k236GmWbCTbDfcZcLauORmJg5GxxoW64PO53CdBRs="
 
 [[package]]
-name = "psmisc"
-version = "23.7-2"
+name = "openssl"
+version = "3.6.2-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/psmisc/psmisc-23.7-2-x86_64.pkg.tar.zst"
-sha256 = "b6722605ae0f2912d7498e87839c702275bfd9280b076e92e80474a847561bd4"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCadv/dAAKCRBtQr3RFuAGj3a1AP9b6+t1o8IsnthUiVxC1ZBI/Av8IpzcdM2+tGzdXObWZwD9Ed2bXM89EbT4fpPIqd8u4nbHS732r33AI3raG9vwDgg="
+url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.6.2-2-x86_64.pkg.tar.zst"
+sha256 = "e8425f1086ce9b4da43f8d02f06eea9f08aebd9f6d25fb6b81cd7bd567db7828"
+signature = "iHUEABYKAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCaeZSuQAKCRB2pe+QVESaXGnBAQCb1toogHtz0Mp8rR3KrwP+EA2jPTdLCHmPcgP61cUmhQEA5NA9+73tdDgR85Hxl6Vq4yfziN5L3BCAfTthfWcgIwQ="
 
 [[package]]
 name = "rust"
-version = "1:1.94.1-1"
+version = "1:1.95.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.94.1-1-x86_64.pkg.tar.zst"
-sha256 = "ca52f83f3a12b61ed8faf370b8efc815b033fca9254b785d7f9a364e80a4a11e"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCacWFvQAKCRC4rAhgDxCM37VAAP94Kytaul2txnzTe48H7yn8fGZrcImhjITMIKNVsVNtDgD/Vv90wbcmarJQhy1oDtXuIUMUaUsq5DUoT/9vNDzpSg0="
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.95.0-1-x86_64.pkg.tar.zst"
+sha256 = "7fb944fe7316c4b56946e97629c1c274c7dd477301f72ff38665e516a961cf61"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaeD+JwAKCRC4rAhgDxCM3+a+AQDYqAJgf84M0ML7M7irZpz+lqnDUPOWdv1f2Ncndw5ilQD/Y5IQ3hhescVkc3Qq957lfwEtFF4JHwVgHDUYSb7NXgM="
 
 [[package]]
 name = "rust-musl"
-version = "1:1.94.1-1"
+version = "1:1.95.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.94.1-1-x86_64.pkg.tar.zst"
-sha256 = "668d51620a126066f3e85d90d4c84185cc02866ffa5dd8b8bd82a8359abec9ba"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCacWFvwAKCRC4rAhgDxCM3ybSAQDZnjKZzTqTujWdAt/e9P0wxynCRaaCr4vS4lycId6W7QEAjio6TDFVjYh+L34gAyjysX3pGLy+TtAzOS1UUf0fNgI="
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.95.0-1-x86_64.pkg.tar.zst"
+sha256 = "362af945af3da46608036f094f73124694d816001810872d728a34fe8af5f683"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaeD+KQAKCRC4rAhgDxCM39dFAP4jpCK0BwjQlfA9DIICUNe81RSMq3dC1LwoGny1v6pYggD8CmDX4Y2TizyqFq53J6i+lTe1jhW6qjtDTxw/MSpO9wQ="
+
+[[package]]
+name = "systemd"
+version = "260.1-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd/systemd-260.1-2-x86_64.pkg.tar.zst"
+sha256 = "552691a335b91a2ec5ad2791e3992201c9078fa1568f5a071dd1ed6ccd023e63"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaeivLwAKCRBtQr3RFuAGj1SgAQC4gNSix9D/Q7TtSGK/I4avunMenkTQAw74uzPXi3TR/QD9H8Z8DZQ4ExdI4D05iNbjchuVXZsZ/VilVAb9J9isIAY="
+
+[[package]]
+name = "systemd-libs"
+version = "260.1-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-260.1-2-x86_64.pkg.tar.zst"
+sha256 = "f1bb2648ac2c0e932e4525b1eaeb5e694a903ae507dfa49f2a5d79c4cfe2024f"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaeivLwAKCRBtQr3RFuAGjy8WAQDTxnxOJqn0tIXZXYpuqF8/LRQrOOjzyBb41kF4ZQqBZAD/TfZsCNjwP79e1y68BaqB97cRE2y3kbGGEYAsSv5VCAg="
+
+[[package]]
+name = "systemd-sysvcompat"
+version = "260.1-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-260.1-2-x86_64.pkg.tar.zst"
+sha256 = "0015a69ca21fee2ca51a7fa454e73e6e8bb4fb3bc0af3e829c9f8b7e9852bbeb"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaeivLwAKCRBtQr3RFuAGj/5DAPsH/MYyWeZqJWWEABMlia8WO6v5XdZEtOsLRvP58UUh7gEAgS2THMVgfcaTv88ua5Zp5uEwTqj3CCcCnqVwwSGQuQ0="
+
+[[package]]
+name = "tzdata"
+version = "2026b-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/t/tzdata/tzdata-2026b-1-x86_64.pkg.tar.zst"
+sha256 = "66501ab147dd891795b5a17d51b3141bd8a643c923efc1445bbd3ed493c65f32"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmnqLdsACgkQlGV6sg8qCSt0WAf/dqXy2e5dsa6oTD9LfSB0U6HgFnXMXCw+dYlaAgkvhA8tKs/+Pd056NCz+FomJFbZgsGLdnBe6Xsk8cTCy2rUVlEoJk11xkvtjiGaHe23sl2ho6njU8CXTaoZBnHcNKcR9/8uFwmAaBoA7rmpve2sUd9k0ORxDmSK5mbopm1QDlmsiMqjGglWytOy1J3T1wdS0GxLSFrAvDjl9Sb0OQ9b0iVzpG7L13fXAw1Z3H1edm3vJrDD5EJgUh4weG4KE2WUGRKXBfRnRhCEKpzChFV9FfUd+sk8YUe/bPiJEIDW9mzkECshXE2veR4QZS6g6QhzPxb5KW7g/NHdWH/Zzb4BIA=="


### PR DESCRIPTION
This is a very minor tweak in the Makefile used to build the official release binary.