### PR TITLE
Add support for running "bootstrap" commands at container creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,21 @@ sha256 = "abccb59dd5b9e64b782bbfd97b08c79a2214cc53567fb334aa003815505a007f"
 # [...]
 ```
 
+## BOOTSTRAP COMMAND
+
+You can declare bootstrap command(s) to run right after the container creation (before dependencies are installed and the build command is executed) with `bootstrap_cmd = [["command", "arg"]]` in the `[container]` section of your **repro-env.toml**. You can pass multiple commands and arguments with `bootstrap_cmd = [["command1", "arg1", "arg2"], ["command2", "arg1", "arg2", "arg3"]]`.
+
+```
+# repro-env.toml
+[container]
+image = "docker.io/archlinux/archlinux:repro"
+bootstrap_cmd = [["pacman-key", "--init"], ["pacman-key", "--populate", "archlinux"]]
+
+[packages]
+system = "archlinux"
+dependencies = ["cargo", "musl", "rust-musl"]
+```
+
 ## Bootstrapping
 
 There are no inherent bootstrapping challenges, you can use any recent Rust compiler to build a working **repro-env** binary. This binary can then setup any other build environment (including it's own) and is able to build a bit-for-bit identical copy of the official release binaries hosted on github.

--- a/docs/repro-env.1.scd
+++ b/docs/repro-env.1.scd
@@ -78,6 +78,21 @@ system = "debian"
 dependencies = ["gcc", "libc6-dev"]
 ```
 
+# BOOTSTRAP COMMAND
+
+You can declare bootstrap command(s) to run right after the container creation (before dependencies are installed and the build command is executed) with *bootstrap_cmd = [["command", "arg"]]* in the *[container]* section of your *repro-env.toml*. You can pass multiple commands and arguments with *bootstrap_cmd = [["command1", "arg1", "arg2"], ["command2", "arg1", "arg2", "arg3"]]*.
+
+```
+# repro-env.toml
+[container]
+image = "docker.io/archlinux/archlinux:repro"
+bootstrap_cmd = [["pacman-key", "--init"], ["pacman-key", "--populate", "archlinux"]]
+
+[packages]
+system = "archlinux"
+dependencies = ["cargo", "musl", "rust-musl"]
+```
+
 # AUTHORS
 
 repro-env is developed on github at https://github.com/kpcyrd/repro-env

--- a/src/build.rs
+++ b/src/build.rs
@@ -234,6 +234,9 @@ pub async fn build(build: &args::Build) -> Result<()> {
         container::Config {
             mounts: &mounts,
             expose_fuse: false,
+            bootstrap_cmd: manifest
+                .as_ref()
+                .and_then(|m| m.container.bootstrap_cmd.as_deref()),
         },
     )
     .await?;

--- a/src/container.rs
+++ b/src/container.rs
@@ -152,6 +152,7 @@ pub async fn inspect(image: &str) -> Result<Image> {
 pub struct Config<'a> {
     pub mounts: &'a [(String, String)],
     pub expose_fuse: bool,
+    pub bootstrap_cmd: Option<&'a [Vec<String>]>,
 }
 
 #[derive(Debug, Default)]
@@ -203,7 +204,35 @@ impl Container {
             out.truncate(idx);
         }
         let id = String::from_utf8(out)?;
-        Ok(Container { id })
+
+        // Run bootstrap commands immediately after creation
+        let container = Container { id };
+        if let Some(cmds) = config.bootstrap_cmd {
+            container.run_bootstrap(cmds).await?;
+        }
+        Ok(container)
+    }
+
+    pub async fn run_bootstrap(&self, cmds: &[Vec<String>]) -> Result<()> {
+        for cmd in cmds {
+            debug!("Running bootstrap command: {:?}", cmd);
+            if let Err(e) = self
+                .exec(
+                    cmd,
+                    Exec {
+                        capture_stdout: false,
+                        cwd: Some("/"),
+                        user: None,
+                        env: &[],
+                    },
+                )
+                .await
+            {
+                let _ = self.kill().await;
+                return Err(e);
+            }
+        }
+        Ok(())
     }
 
     pub async fn exec<I, S>(&self, args: I, options: Exec<'_>) -> Result<Vec<u8>>

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -35,6 +35,7 @@ impl Lockfile {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContainerLock {
     pub image: String,
+    pub bootstrap_cmd: Option<Vec<Vec<String>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -70,6 +71,7 @@ mod tests {
                 image:
                     "docker.io/library/archlinux@sha256:6568d3f1f278827a4a7d8537f80c2ae36982829a0c6bccff4cec081774025472"
                         .to_string(),
+                bootstrap_cmd: None,
             },
             packages: vec![
                 PackageLock {
@@ -135,6 +137,7 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZG6Rg18UgAAAAAAuAChpc3N
                 image:
                     "debian@sha256:3d868b5eb908155f3784317b3dda2941df87bbbbaa4608f84881de66d9bb297b"
                         .to_string(),
+                bootstrap_cmd: None,
             },
             packages: vec![
                 PackageLock {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -51,6 +51,8 @@ impl Manifest {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ContainerManifest {
     pub image: String,
+    #[serde(default)]
+    pub bootstrap_cmd: Option<Vec<Vec<String>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -77,6 +79,7 @@ image = "docker.io/library/rust:1-alpine"
             Manifest {
                 container: ContainerManifest {
                     image: "docker.io/library/rust:1-alpine".to_string(),
+                    bootstrap_cmd: None,
                 },
                 packages: None
             }

--- a/src/resolver/alpine.rs
+++ b/src/resolver/alpine.rs
@@ -374,6 +374,7 @@ pub async fn resolve(
         container::Config {
             mounts: &[],
             expose_fuse: false,
+            bootstrap_cmd: None,
         },
     )
     .await?;

--- a/src/resolver/archlinux.rs
+++ b/src/resolver/archlinux.rs
@@ -208,6 +208,7 @@ pub async fn resolve(
         container::Config {
             mounts: &[],
             expose_fuse: false,
+            bootstrap_cmd: None,
         },
     )
     .await?;

--- a/src/resolver/container.rs
+++ b/src/resolver/container.rs
@@ -21,5 +21,6 @@ pub async fn resolve(args: &args::Update, manifest: &Manifest) -> Result<Contain
 
     Ok(ContainerLock {
         image: pinned_image,
+        bootstrap_cmd: None,
     })
 }

--- a/src/resolver/debian.rs
+++ b/src/resolver/debian.rs
@@ -290,6 +290,7 @@ pub async fn resolve(
         container::Config {
             mounts: &[],
             expose_fuse: false,
+            bootstrap_cmd: None,
         },
     )
     .await?;


### PR DESCRIPTION
Add support for defining "bootstrap" commands in the `[container]` section of `repro-env.toml`, which are executed right after the container creation (before dependencies installation and build command execution).

This is allows to run pre / init command to prepare the environment if needed (similar to the `before_script` mechanic in GitLab CI for instance).

One use case example is to be able to use the new [archlinux `repro` image](https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/44PW52T547MACXFU5HZ5U7SIPAX3BAXS/) which has the pacman keyring stripped out by default for reproducibility matters (and that should therefore be initialized before being able to install dependencies):

```toml
[container]
image = "docker.io/archlinux/archlinux:repro"
bootstrap_cmd = [["pacman-key", "--init"], ["pacman-key", "--populate", "archlinux"]]

[packages]
system = "archlinux"
dependencies = ["cargo", "musl", "rust-musl"]
```