### PR TITLE
Add oniri to the list of projects that adopted repro-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following projects use repro-env to publish independently verifiable release
 - [archlinux-userland-fs-cmp](https://github.com/kpcyrd/archlinux-userland-fs-cmp)
 - [ic-gateway](https://github.com/dfinity/ic-gateway)
 - [ic-http-lb](https://github.com/dfinity/ic-http-lb)
+- [oniri](https://github.com/Antiz96/oniri)
 - [repro-env](https://github.com/kpcyrd/repro-env)
 - [rshijack](https://github.com/kpcyrd/rshijack)
 - [sh4d0wup](https://github.com/kpcyrd/sh4d0wup)


### PR DESCRIPTION
Hey :wave: 

I adopted `repro-env` to build and provide independently verifiably release binaries for my [oniri](https://github.com/Antiz96/oniri) project. I thought I'd add it to the "Adoption" section :hugs: 